### PR TITLE
Exclude 0-duration sessions from weekly activity, calendar, and recent log

### DIFF
--- a/js/activity.js
+++ b/js/activity.js
@@ -31,7 +31,8 @@ function renderCalendar(sessions) {
   const container = document.getElementById('activityCalendar');
   if (!container) return;
 
-  // Build a map of date -> points earned
+  // Build a map of date -> points earned (exclude historical sessions with no duration)
+  sessions = sessions.filter(s => s.duration);
   const byDate = {};
   sessions.forEach(s => {
     if (!s.date) return;

--- a/js/dashboard.js
+++ b/js/dashboard.js
@@ -130,7 +130,7 @@ function getWeekBounds() {
 
 function renderWeeklySummary() {
   const { start, end } = getWeekBounds();
-  const sessions = (appData.sessions || []).filter(s => s.date >= start && s.date <= end);
+  const sessions = (appData.sessions || []).filter(s => s.date >= start && s.date <= end && s.duration);
   const goal = appData.config.weeklyGoal || 0;
 
   // Points this week
@@ -337,7 +337,7 @@ function formatDate(dateStr) {
 }
 
 function renderRecentSessions() {
-  const sessions = [...appData.sessions].reverse().slice(0, 5);
+  const sessions = [...appData.sessions].filter(s => s.duration).reverse().slice(0, 5);
   if (!sessions.length) return '<p class="empty-text">No sessions logged yet.</p>';
 
   return `<div class="session-list">


### PR DESCRIPTION
Sessions logged without a minute duration are treated as historical records
and filtered out of the weekly summary, GitHub-style activity calendar, and
the recent activity log on the dashboard. The full session history list is
unaffected so historical entries remain visible there.

Fixes #8

https://claude.ai/code/session_01TD4zEV36VgSGwTUSg84X73