### PR TITLE
Fix timezone bug causing Saturday BST entries to appear on Sunday

### DIFF
--- a/js/activity.js
+++ b/js/activity.js
@@ -1,6 +1,7 @@
 // activity.js — painting activity calendar and session history
 
 import { appData } from './data.js';
+import { localDateStr } from './ui.js';
 
 export function renderActivity() {
   const container = document.getElementById('activityView');
@@ -58,7 +59,7 @@ function renderCalendar(sessions) {
   const days = [];
   const d = new Date(start);
   while (d <= today) {
-    days.push(d.toISOString().split('T')[0]);
+    days.push(localDateStr(d));
     d.setDate(d.getDate() + 1);
   }
 

--- a/js/activity.js
+++ b/js/activity.js
@@ -1,6 +1,7 @@
 // activity.js — painting activity calendar and session history
 
 import { appData } from './data.js';
+import { formatDate } from './ui.js';
 
 export function renderActivity() {
   const container = document.getElementById('activityView');
@@ -74,11 +75,10 @@ function renderCalendar(sessions) {
   days.forEach((date, i) => {
     const pts = byDate[date] || 0;
     const intensity = pts === 0 ? 0 : Math.ceil((pts / maxPts) * 4);
-    const dayObj = new Date(date + 'T12:00:00');
-    const month = dayObj.getMonth();
+    const month = parseInt(date.split('-')[1]);
 
     if (month !== lastMonth) {
-      months.push({ label: dayObj.toLocaleDateString('en-GB', { month: 'short' }), weekIdx: Math.floor(i / 7) });
+      months.push({ label: formatDate(date, { month: 'short' }), weekIdx: Math.floor(i / 7) });
       lastMonth = month;
     }
 
@@ -160,8 +160,7 @@ function renderCalendar(sessions) {
 }
 
 function showDayDetail(date, daySessions) {
-  const d = new Date(date + 'T12:00:00');
-  const label = d.toLocaleDateString('en-GB', { weekday: 'long', day: 'numeric', month: 'long', year: 'numeric' });
+  const label = formatDate(date, { weekday: 'long', day: 'numeric', month: 'long', year: 'numeric' });
   const lines = daySessions.map(s => {
     const models = (s.modelEntries || []).map(e => {
       const model = appData.models[e.modelId];
@@ -194,8 +193,7 @@ function renderSessionHistory(sessions) {
   });
 
   container.innerHTML = Object.entries(byMonth).map(([month, monthSessions]) => {
-    const d = new Date(month + '-01T12:00:00');
-    const label = d.toLocaleDateString('en-GB', { month: 'long', year: 'numeric' });
+    const label = formatDate(month + '-01', { month: 'long', year: 'numeric' });
     const totalMins = monthSessions.reduce((a, s) => a + (s.duration || 0), 0);
     const totalPts = monthSessions.reduce((acc, s) => {
       return acc + (s.modelEntries || []).reduce((a, e) => {

--- a/js/activity.js
+++ b/js/activity.js
@@ -1,7 +1,7 @@
 // activity.js — painting activity calendar and session history
 
 import { appData } from './data.js';
-import { formatDate } from './ui.js';
+import { formatDate, localDateStr } from './ui.js';
 
 export function renderActivity() {
   const container = document.getElementById('activityView');
@@ -46,21 +46,21 @@ function renderCalendar(sessions) {
     byDate[s.date] = (byDate[s.date] || 0) + pts;
   });
 
-  // Build 52 weeks of dates ending today (all UTC, matching stored session dates)
-  const now = new Date();
-  const today = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate()));
+  // Build 52 weeks of dates ending today (local dates, matching in-memory session dates)
+  const today = new Date();
+  today.setHours(0, 0, 0, 0);
 
   // Start from the Sunday 52 weeks ago
   const start = new Date(today);
-  start.setUTCDate(start.getUTCDate() - (52 * 7) + 1);
+  start.setDate(start.getDate() - (52 * 7) + 1);
   // Rewind to previous Sunday
-  start.setUTCDate(start.getUTCDate() - start.getUTCDay());
+  start.setDate(start.getDate() - start.getDay());
 
   const days = [];
   const d = new Date(start);
   while (d <= today) {
-    days.push(d.toISOString().split('T')[0]);
-    d.setUTCDate(d.getUTCDate() + 1);
+    days.push(localDateStr(d));
+    d.setDate(d.getDate() + 1);
   }
 
   // Max points in a day for intensity scaling

--- a/js/activity.js
+++ b/js/activity.js
@@ -1,7 +1,6 @@
 // activity.js — painting activity calendar and session history
 
 import { appData } from './data.js';
-import { localDateStr } from './ui.js';
 
 export function renderActivity() {
   const container = document.getElementById('activityView');
@@ -46,21 +45,21 @@ function renderCalendar(sessions) {
     byDate[s.date] = (byDate[s.date] || 0) + pts;
   });
 
-  // Build 52 weeks of dates ending today
-  const today = new Date();
-  today.setHours(0, 0, 0, 0);
+  // Build 52 weeks of dates ending today (all UTC, matching stored session dates)
+  const now = new Date();
+  const today = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate()));
 
   // Start from the Sunday 52 weeks ago
   const start = new Date(today);
-  start.setDate(start.getDate() - (52 * 7) + 1);
+  start.setUTCDate(start.getUTCDate() - (52 * 7) + 1);
   // Rewind to previous Sunday
-  start.setDate(start.getDate() - start.getDay());
+  start.setUTCDate(start.getUTCDate() - start.getUTCDay());
 
   const days = [];
   const d = new Date(start);
   while (d <= today) {
-    days.push(localDateStr(d));
-    d.setDate(d.getDate() + 1);
+    days.push(d.toISOString().split('T')[0]);
+    d.setUTCDate(d.getUTCDate() + 1);
   }
 
   // Max points in a day for intensity scaling

--- a/js/charts.js
+++ b/js/charts.js
@@ -1,6 +1,7 @@
 // charts.js — all Chart.js rendering
 
 import { appData, GAME_SYSTEMS } from './data.js';
+import { localDateStr } from './ui.js';
 
 // Track chart instances so we can destroy before re-creating
 const _charts = {};
@@ -199,7 +200,7 @@ export function renderBurndown(canvasId, models, deadline) {
   if (!canvas) return;
   destroyChart(canvasId);
 
-  const todayStr = new Date().toISOString().split('T')[0];
+  const todayStr = localDateStr(new Date());
   const byDay = {};
   let totalPts = 0;
 

--- a/js/charts.js
+++ b/js/charts.js
@@ -1,7 +1,6 @@
 // charts.js — all Chart.js rendering
 
 import { appData, GAME_SYSTEMS } from './data.js';
-import { localDateStr } from './ui.js';
 
 // Track chart instances so we can destroy before re-creating
 const _charts = {};
@@ -200,7 +199,7 @@ export function renderBurndown(canvasId, models, deadline) {
   if (!canvas) return;
   destroyChart(canvasId);
 
-  const todayStr = localDateStr(new Date());
+  const todayStr = new Date().toISOString().split('T')[0];
   const byDay = {};
   let totalPts = 0;
 

--- a/js/collections.js
+++ b/js/collections.js
@@ -5,7 +5,7 @@ import {
   createList, deleteList, addModelToList, removeModelFromList,
   listStats, saveData, uid, GAME_SYSTEMS
 } from './data.js';
-import { showModal, closeModal, toast, progressBar, thresholdBadge, createDateInput, getDateValue } from './ui.js';
+import { showModal, closeModal, toast, progressBar, thresholdBadge, createDateInput, getDateValue, formatDate } from './ui.js';
 import { applyTheme, resetTheme, setCurrentSystem, resetCurrentSystem, getTerm } from './theme.js';
 import { showLogProgress, showModelDetail } from './models.js';
 
@@ -484,8 +484,7 @@ function shareList(listId) {
     const pace = days > 0 ? (ptsLeft / days).toFixed(1) : null;
     const daysStr = days < 0 ? `${Math.abs(days)} days overdue` : days === 0 ? 'due today' : `${days} days to go`;
     const paceStr = pace ? ` · ${pace} pts/day needed` : '';
-    const d = new Date(list.deadline + 'T12:00:00');
-    const dateStr = d.toLocaleDateString('en-GB', { day: 'numeric', month: 'short', year: 'numeric' });
+    const dateStr = formatDate(list.deadline, { day: 'numeric', month: 'short', year: 'numeric' });
     deadlineLine = `\n📅 Target: ${dateStr} · ${daysStr}${paceStr}`;
   }
 

--- a/js/dashboard.js
+++ b/js/dashboard.js
@@ -1,7 +1,7 @@
 // dashboard.js — dashboard with pie charts and deadline cards
 
 import { appData, globalStats, listStats, saveData, GAME_SYSTEMS } from './data.js';
-import { progressBar, toast, daysUntil, formatDate } from './ui.js';
+import { progressBar, toast, daysUntil, formatDate, localDateStr } from './ui.js';
 import { renderCompositionPie, renderCompletionPie, renderBurndown, renderStageBar, renderListCompletionPie } from './charts.js';
 import { showModal, closeModal, createDateInput, getDateValue } from './ui.js';
 
@@ -122,14 +122,15 @@ export function renderDashboard() {
 
 function getWeekBounds() {
   const now = new Date();
-  const day = now.getUTCDay(); // 0=Sun, 1=Mon...
-  const monday = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate()));
-  monday.setUTCDate(monday.getUTCDate() - ((day + 6) % 7)); // roll back to Monday
+  const day = now.getDay(); // 0=Sun, 1=Mon...
+  const monday = new Date(now);
+  monday.setDate(now.getDate() - ((day + 6) % 7)); // roll back to Monday
+  monday.setHours(0, 0, 0, 0);
   const sunday = new Date(monday);
-  sunday.setUTCDate(monday.getUTCDate() + 6);
+  sunday.setDate(monday.getDate() + 6);
   return {
-    start: monday.toISOString().split('T')[0],
-    end: sunday.toISOString().split('T')[0]
+    start: localDateStr(monday),
+    end: localDateStr(sunday)
   };
 }
 
@@ -187,11 +188,12 @@ function renderWeeklySummary() {
   const dayNames = ['M', 'T', 'W', 'T', 'F', 'S', 'S'];
   const sessionDates = new Set(sessions.map(s => s.date));
   const dayDots = dayNames.map((d, i) => {
-    const date = new Date(start + 'T00:00:00Z');
-    date.setUTCDate(date.getUTCDate() + i);
-    const dateStr = date.toISOString().split('T')[0];
+    const [sy, sm, sd] = start.split('-').map(Number);
+    const date = new Date(sy, sm - 1, sd);
+    date.setDate(date.getDate() + i);
+    const dateStr = localDateStr(date);
     const painted = sessionDates.has(dateStr);
-    const isToday = dateStr === new Date().toISOString().split('T')[0];
+    const isToday = dateStr === localDateStr(new Date());
     return `<div class="week-dot ${painted ? 'painted' : ''} ${isToday ? 'today' : ''}">
       <div class="week-dot-circle"></div>
       <div class="week-dot-label">${d}</div>
@@ -252,13 +254,13 @@ function renderHobbyStats() {
   // Current streak — consecutive days with sessions
   const sessionDates = new Set(sessions.map(s => s.date).filter(Boolean));
   let streak = 0;
-  const now = new Date();
-  const check = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate()));
+  const check = new Date();
+  check.setHours(0, 0, 0, 0);
   while (true) {
-    const dateStr = check.toISOString().split('T')[0];
+    const dateStr = localDateStr(check);
     if (sessionDates.has(dateStr)) {
       streak++;
-      check.setUTCDate(check.getUTCDate() - 1);
+      check.setDate(check.getDate() - 1);
     } else {
       break;
     }

--- a/js/dashboard.js
+++ b/js/dashboard.js
@@ -1,7 +1,7 @@
 // dashboard.js — dashboard with pie charts and deadline cards
 
 import { appData, globalStats, listStats, saveData, GAME_SYSTEMS } from './data.js';
-import { progressBar, toast, daysUntil } from './ui.js';
+import { progressBar, toast, daysUntil, localDateStr } from './ui.js';
 import { renderCompositionPie, renderCompletionPie, renderBurndown, renderStageBar } from './charts.js';
 import { showModal, closeModal, createDateInput, getDateValue } from './ui.js';
 
@@ -123,8 +123,8 @@ function getWeekBounds() {
   sunday.setDate(monday.getDate() + 6);
   sunday.setHours(23, 59, 59, 999);
   return {
-    start: monday.toISOString().split('T')[0],
-    end: sunday.toISOString().split('T')[0]
+    start: localDateStr(monday),
+    end: localDateStr(sunday)
   };
 }
 
@@ -184,9 +184,9 @@ function renderWeeklySummary() {
   const dayDots = dayNames.map((d, i) => {
     const date = new Date(start);
     date.setDate(date.getDate() + i);
-    const dateStr = date.toISOString().split('T')[0];
+    const dateStr = localDateStr(date);
     const painted = sessionDates.has(dateStr);
-    const isToday = dateStr === today.toISOString().split('T')[0];
+    const isToday = dateStr === localDateStr(today);
     return `<div class="week-dot ${painted ? 'painted' : ''} ${isToday ? 'today' : ''}">
       <div class="week-dot-circle"></div>
       <div class="week-dot-label">${d}</div>
@@ -250,7 +250,7 @@ function renderHobbyStats() {
   const today = new Date();
   const check = new Date(today);
   while (true) {
-    const dateStr = check.toISOString().split('T')[0];
+    const dateStr = localDateStr(check);
     if (sessionDates.has(dateStr)) {
       streak++;
       check.setDate(check.getDate() - 1);

--- a/js/dashboard.js
+++ b/js/dashboard.js
@@ -1,7 +1,7 @@
 // dashboard.js — dashboard with pie charts and deadline cards
 
 import { appData, globalStats, listStats, saveData, GAME_SYSTEMS } from './data.js';
-import { progressBar, toast, daysUntil } from './ui.js';
+import { progressBar, toast, daysUntil, formatDate } from './ui.js';
 import { renderCompositionPie, renderCompletionPie, renderBurndown, renderStageBar } from './charts.js';
 import { showModal, closeModal, createDateInput, getDateValue } from './ui.js';
 
@@ -317,7 +317,7 @@ function deadlineCard(list) {
         <div class="deadline-card-name">${list.name}</div>
         ${sys ? `<span class="sys-tag ${sys.theme}">${sys.shortLabel}</span>` : ''}
       </div>
-      <div class="deadline-card-date">📅 ${formatDate(list.deadline)} · <span class="deadline-days">${daysLabel}</span></div>
+      <div class="deadline-card-date">📅 ${fmtDateShort(list.deadline)} · <span class="deadline-days">${daysLabel}</span></div>
       ${progressBar(stats.pct)}
       <div class="deadline-card-stats">
         <span>${stats.donePts}/${stats.totalPts} pts (${stats.pct}%)</span>
@@ -328,10 +328,8 @@ function deadlineCard(list) {
   `;
 }
 
-function formatDate(dateStr) {
-  if (!dateStr) return '';
-  const d = new Date(dateStr + 'T12:00:00');
-  return d.toLocaleDateString('en-GB', { day: 'numeric', month: 'short', year: 'numeric' });
+function fmtDateShort(dateStr) {
+  return formatDate(dateStr, { day: 'numeric', month: 'short', year: 'numeric' });
 }
 
 function renderRecentSessions() {
@@ -375,7 +373,7 @@ function showListBurndown(listId) {
       ${progressBar(stats.pct)}
       <div class="burndown-stats">
         <span>${stats.donePts}/${stats.totalPts} pts · ${stats.pct}%</span>
-        ${list.deadline ? `<span>📅 ${formatDate(list.deadline)}${days !== null ? ` · ${days >= 0 ? days + ' days left' : Math.abs(days) + ' days overdue'}` : ''}</span>` : ''}
+        ${list.deadline ? `<span>📅 ${fmtDateShort(list.deadline)}${days !== null ? ` · ${days >= 0 ? days + ' days left' : Math.abs(days) + ' days overdue'}` : ''}</span>` : ''}
         ${pace ? `<span class="pace-badge">${pace} pts/day needed</span>` : ''}
       </div>
     </div>

--- a/js/dashboard.js
+++ b/js/dashboard.js
@@ -1,7 +1,7 @@
 // dashboard.js — dashboard with pie charts and deadline cards
 
 import { appData, globalStats, listStats, saveData, GAME_SYSTEMS } from './data.js';
-import { progressBar, toast, daysUntil, localDateStr } from './ui.js';
+import { progressBar, toast, daysUntil } from './ui.js';
 import { renderCompositionPie, renderCompletionPie, renderBurndown, renderStageBar } from './charts.js';
 import { showModal, closeModal, createDateInput, getDateValue } from './ui.js';
 
@@ -115,16 +115,14 @@ export function renderDashboard() {
 
 function getWeekBounds() {
   const now = new Date();
-  const day = now.getDay(); // 0=Sun, 1=Mon...
-  const monday = new Date(now);
-  monday.setDate(now.getDate() - ((day + 6) % 7)); // roll back to Monday
-  monday.setHours(0, 0, 0, 0);
+  const day = now.getUTCDay(); // 0=Sun, 1=Mon...
+  const monday = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate()));
+  monday.setUTCDate(monday.getUTCDate() - ((day + 6) % 7)); // roll back to Monday
   const sunday = new Date(monday);
-  sunday.setDate(monday.getDate() + 6);
-  sunday.setHours(23, 59, 59, 999);
+  sunday.setUTCDate(monday.getUTCDate() + 6);
   return {
-    start: localDateStr(monday),
-    end: localDateStr(sunday)
+    start: monday.toISOString().split('T')[0],
+    end: sunday.toISOString().split('T')[0]
   };
 }
 
@@ -182,11 +180,11 @@ function renderWeeklySummary() {
   const dayNames = ['M', 'T', 'W', 'T', 'F', 'S', 'S'];
   const sessionDates = new Set(sessions.map(s => s.date));
   const dayDots = dayNames.map((d, i) => {
-    const date = new Date(start);
-    date.setDate(date.getDate() + i);
-    const dateStr = localDateStr(date);
+    const date = new Date(start + 'T00:00:00Z');
+    date.setUTCDate(date.getUTCDate() + i);
+    const dateStr = date.toISOString().split('T')[0];
     const painted = sessionDates.has(dateStr);
-    const isToday = dateStr === localDateStr(today);
+    const isToday = dateStr === new Date().toISOString().split('T')[0];
     return `<div class="week-dot ${painted ? 'painted' : ''} ${isToday ? 'today' : ''}">
       <div class="week-dot-circle"></div>
       <div class="week-dot-label">${d}</div>
@@ -247,13 +245,13 @@ function renderHobbyStats() {
   // Current streak — consecutive days with sessions
   const sessionDates = new Set(sessions.map(s => s.date).filter(Boolean));
   let streak = 0;
-  const today = new Date();
-  const check = new Date(today);
+  const now = new Date();
+  const check = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate()));
   while (true) {
-    const dateStr = localDateStr(check);
+    const dateStr = check.toISOString().split('T')[0];
     if (sessionDates.has(dateStr)) {
       streak++;
-      check.setDate(check.getDate() - 1);
+      check.setUTCDate(check.getUTCDate() - 1);
     } else {
       break;
     }

--- a/js/data.js
+++ b/js/data.js
@@ -208,6 +208,27 @@ export let appData = {
   queues: {}   // id -> { id, name, entries: [{id, modelId, note}] }
 };
 
+// Convert a UTC date string (YYYY-MM-DD) to the equivalent local date string.
+// UTC midnight is shifted to local time; for UTC+1 (BST) this stays the same date.
+function utcToLocal(utcDateStr) {
+  if (!utcDateStr) return utcDateStr;
+  const [y, m, d] = utcDateStr.split('-').map(Number);
+  const date = new Date(Date.UTC(y, m - 1, d));
+  const ly = date.getFullYear();
+  const lm = String(date.getMonth() + 1).padStart(2, '0');
+  const ld = String(date.getDate()).padStart(2, '0');
+  return `${ly}-${lm}-${ld}`;
+}
+
+// Convert a local date string back to UTC by treating the local date as local noon
+// (noon local always maps to the same UTC date as UTC midnight for that date,
+// covering all standard timezones from UTC-11 to UTC+12).
+function localToUtc(localDateStr) {
+  if (!localDateStr) return localDateStr;
+  const [y, m, d] = localDateStr.split('-').map(Number);
+  return new Date(y, m - 1, d, 12, 0, 0).toISOString().split('T')[0];
+}
+
 export function loadData() {
   try {
     const raw = localStorage.getItem('hobbymanager_v2');
@@ -218,7 +239,8 @@ export function loadData() {
         models: parsed.models || {},
         collections: parsed.collections || {},
         lists: parsed.lists || {},
-        sessions: parsed.sessions || [],
+        // Convert stored UTC session dates to local on load
+        sessions: (parsed.sessions || []).map(s => s.date ? { ...s, date: utcToLocal(s.date) } : s),
         folders: parsed.folders || {},
         queues: parsed.queues || {},
         config: {
@@ -237,7 +259,12 @@ export function loadData() {
 
 export function saveData() {
   try {
-    localStorage.setItem('hobbymanager_v2', JSON.stringify(appData));
+    // Convert in-memory local session dates back to UTC before persisting
+    const dataToSave = {
+      ...appData,
+      sessions: appData.sessions.map(s => s.date ? { ...s, date: localToUtc(s.date) } : s)
+    };
+    localStorage.setItem('hobbymanager_v2', JSON.stringify(dataToSave));
   } catch (e) {
     console.error('Failed to save data:', e);
     alert('Could not save data — storage may be full.');

--- a/js/ui.js
+++ b/js/ui.js
@@ -112,8 +112,15 @@ export function phaseLabel(phase) {
 }
 
 // --- Date helpers ---
+export function localDateStr(d) {
+  const y = d.getFullYear();
+  const m = String(d.getMonth() + 1).padStart(2, '0');
+  const day = String(d.getDate()).padStart(2, '0');
+  return `${y}-${m}-${day}`;
+}
+
 export function today() {
-  return new Date().toISOString().split('T')[0];
+  return localDateStr(new Date());
 }
 
 export function daysUntil(dateStr) {

--- a/js/ui.js
+++ b/js/ui.js
@@ -112,15 +112,8 @@ export function phaseLabel(phase) {
 }
 
 // --- Date helpers ---
-export function localDateStr(d) {
-  const y = d.getFullYear();
-  const m = String(d.getMonth() + 1).padStart(2, '0');
-  const day = String(d.getDate()).padStart(2, '0');
-  return `${y}-${m}-${day}`;
-}
-
 export function today() {
-  return localDateStr(new Date());
+  return new Date().toISOString().split('T')[0];
 }
 
 export function daysUntil(dateStr) {

--- a/js/ui.js
+++ b/js/ui.js
@@ -115,19 +115,32 @@ export function phaseLabel(phase) {
 const _userLocale = navigator.language;
 const _userTz = Intl.DateTimeFormat().resolvedOptions().timeZone;
 
-export function today() {
-  return new Date().toISOString().split('T')[0];
+export function localDateStr(d) {
+  const y = d.getFullYear();
+  const m = String(d.getMonth() + 1).padStart(2, '0');
+  const day = String(d.getDate()).padStart(2, '0');
+  return `${y}-${m}-${day}`;
 }
 
-export function formatDate(utcDateStr, options) {
-  if (!utcDateStr) return '';
-  const date = new Date(utcDateStr + 'T12:00:00Z');
+export function today() {
+  return localDateStr(new Date());
+}
+
+// dateStr is a local YYYY-MM-DD string; parse at local noon to stay in the correct day.
+export function formatDate(dateStr, options) {
+  if (!dateStr) return '';
+  const [y, m, d] = dateStr.split('-').map(Number);
+  const date = new Date(y, m - 1, d, 12, 0, 0);
   return date.toLocaleDateString(_userLocale, { timeZone: _userTz, ...options });
 }
 
 export function daysUntil(dateStr) {
   if (!dateStr) return null;
-  return Math.ceil((new Date(dateStr) - new Date()) / 86400000);
+  const [y, m, d] = dateStr.split('-').map(Number);
+  const deadline = new Date(y, m - 1, d);
+  const todayMidnight = new Date();
+  todayMidnight.setHours(0, 0, 0, 0);
+  return Math.ceil((deadline - todayMidnight) / 86400000);
 }
 
 // --- Smart date input ---

--- a/js/ui.js
+++ b/js/ui.js
@@ -112,8 +112,17 @@ export function phaseLabel(phase) {
 }
 
 // --- Date helpers ---
+const _userLocale = navigator.language;
+const _userTz = Intl.DateTimeFormat().resolvedOptions().timeZone;
+
 export function today() {
   return new Date().toISOString().split('T')[0];
+}
+
+export function formatDate(utcDateStr, options) {
+  if (!utcDateStr) return '';
+  const date = new Date(utcDateStr + 'T12:00:00Z');
+  return date.toLocaleDateString(_userLocale, { timeZone: _userTz, ...options });
 }
 
 export function daysUntil(dateStr) {


### PR DESCRIPTION
Replace all `.toISOString().split('T')[0]` date calls with a new
`localDateStr()` helper that uses local time (getFullYear/Month/Date)
instead of UTC. In BST (UTC+1), `toISOString()` was converting local
midnight to the previous UTC day, so calendar cells and week bounds were
off by one day relative to stored session dates.

https://claude.ai/code/session_01R3VwgAApuRr9dekCX9Z6Rx