### PR TITLE
Add army completion breakdown pie charts (issue #11)

### DIFF
--- a/index.html
+++ b/index.html
@@ -862,6 +862,13 @@
     .chart-wrap { height: 200px; position: relative; }
     .dash-chart-card { overflow: hidden; }
 
+    .dash-army-breakdown { grid-column: 1 / -1; }
+    .army-pie-grid { display: flex; flex-wrap: wrap; gap: 1rem; }
+    .army-pie-card { flex: 1 1 200px; min-width: 180px; max-width: 280px; }
+    .army-pie-title { font-size: 0.85em; font-weight: 600; margin-bottom: 0.5rem; display: flex; align-items: center; gap: 0.4rem; flex-wrap: wrap; }
+    .list-completion-chart { margin-top: 1rem; }
+    .list-completion-chart .chart-wrap { height: 220px; }
+
     .session-list { display: flex; flex-direction: column; gap: 0.5em; }
     .session-item { padding: 0.5em; background: var(--surface2); border-radius: var(--radius); font-size: 0.85em; }
     .session-date { font-weight: 700; color: var(--accent); }

--- a/js/charts.js
+++ b/js/charts.js
@@ -140,6 +140,52 @@ export function renderCompletionPie(canvasId) {
 }
 
 // ----------------------------------------------------------------
+// PIE: Completion status for a specific army list
+// ----------------------------------------------------------------
+export function renderListCompletionPie(canvasId, models) {
+  const canvas = document.getElementById(canvasId);
+  if (!canvas) return;
+  destroyChart(canvasId);
+
+  let finished = 0, painted = 0, tableReady = 0, inProgress = 0;
+  models.forEach(m => {
+    const thresh = calcModelThreshold(m);
+    const qty = m.quantity;
+    if (thresh === 'finished')         finished   += qty;
+    else if (thresh === 'painted')     painted    += qty;
+    else if (thresh === 'table_ready') tableReady += qty;
+    else                               inProgress += qty;
+  });
+
+  const total = finished + painted + tableReady + inProgress;
+  if (!total) {
+    canvas.parentElement.innerHTML = '<p class="empty-text">No models in this list.</p>';
+    return;
+  }
+
+  _charts[canvasId] = new Chart(canvas.getContext('2d'), {
+    type: 'doughnut',
+    data: {
+      labels: ['🏆 Finished', '🎨 Painted', '⚔️ Table Ready', '🔧 In Progress'],
+      datasets: [{
+        data: [finished, painted, tableReady, inProgress],
+        backgroundColor: ['#c5a028', '#4a9d6f', '#8b7355', '#2a2a3a'],
+        borderColor: '#1a1a2e',
+        borderWidth: 2
+      }]
+    },
+    options: {
+      responsive: true,
+      maintainAspectRatio: false,
+      plugins: {
+        legend: { position: 'bottom', labels: { color: '#ccc', padding: 10, font: { size: 11 } } },
+        tooltip: { callbacks: { label: ctx => ` ${ctx.label}: ${ctx.parsed} (${Math.round(ctx.parsed/total*100)}%)` } }
+      }
+    }
+  });
+}
+
+// ----------------------------------------------------------------
 // BAR: Stage breakdown for a list (shown in burndown modal)
 // ----------------------------------------------------------------
 export function renderStageBar(canvasId, models) {

--- a/js/collections.js
+++ b/js/collections.js
@@ -8,6 +8,7 @@ import {
 import { showModal, closeModal, toast, progressBar, thresholdBadge, createDateInput, getDateValue } from './ui.js';
 import { applyTheme, resetTheme, setCurrentSystem, resetCurrentSystem, getTerm } from './theme.js';
 import { showLogProgress, showModelDetail } from './models.js';
+import { renderListCompletionPie } from './charts.js';
 
 let activeCollectionId = null;
 let activeListId = null;
@@ -179,6 +180,10 @@ function selectList(listId) {
         ${list.deadline ? `<button class="btn btn-xs btn-danger" id="clearDeadlineBtn">✕</button>` : ''}
       </div>
     </div>
+    <div class="dash-card list-completion-chart">
+      <h3>Completion Breakdown</h3>
+      <div class="chart-wrap"><canvas id="listCompletionPieChart"></canvas></div>
+    </div>
     <div class="list-models-header">
       <h3>${getTerm('group')}s / ${getTerm('model')}s</h3>
       <button class="btn btn-primary btn-sm" id="addModelToListBtn">+ Add from Pool</button>
@@ -227,6 +232,7 @@ function selectList(listId) {
       selectList(listId);
     });
   });
+  requestAnimationFrame(() => renderListCompletionPie('listCompletionPieChart', models));
 }
 
 function listModelRow(model, listId) {

--- a/js/dashboard.js
+++ b/js/dashboard.js
@@ -2,7 +2,7 @@
 
 import { appData, globalStats, listStats, saveData, GAME_SYSTEMS } from './data.js';
 import { progressBar, toast, daysUntil } from './ui.js';
-import { renderCompositionPie, renderCompletionPie, renderBurndown, renderStageBar } from './charts.js';
+import { renderCompositionPie, renderCompletionPie, renderBurndown, renderStageBar, renderListCompletionPie } from './charts.js';
 import { showModal, closeModal, createDateInput, getDateValue } from './ui.js';
 
 export function renderDashboard() {
@@ -87,6 +87,9 @@ export function renderDashboard() {
         ${renderRecentSessions()}
       </div>
 
+      <!-- Army completion breakdown -->
+      ${armyCompletionSection()}
+
     </div>
   `;
 
@@ -110,6 +113,10 @@ export function renderDashboard() {
   requestAnimationFrame(() => {
     renderCompletionPie('completionPie');
     renderCompositionPie('compositionPie');
+    Object.values(appData.lists).forEach(list => {
+      const models = (list.modelIds || []).map(id => appData.models[id]).filter(Boolean);
+      renderListCompletionPie(`armyPie_${list.id}`, models);
+    });
   });
 }
 
@@ -358,6 +365,29 @@ function renderRecentSessions() {
       </div>
     `).join('')}
   </div>`;
+}
+
+function armyCompletionSection() {
+  const lists = Object.values(appData.lists);
+  if (!lists.length) return '';
+  return `
+    <div class="dash-card dash-army-breakdown">
+      <h3>Army Completion Breakdown</h3>
+      <div class="army-pie-grid">
+        ${lists.map(list => {
+          const col = appData.collections[list.collectionId];
+          const sys = col ? GAME_SYSTEMS[col.gameSystemId] : null;
+          return `
+            <div class="army-pie-card">
+              <div class="army-pie-title">
+                ${list.name}
+                ${sys ? `<span class="sys-tag ${sys.theme}">${sys.shortLabel}</span>` : ''}
+              </div>
+              <div class="chart-wrap"><canvas id="armyPie_${list.id}"></canvas></div>
+            </div>`;
+        }).join('')}
+      </div>
+    </div>`;
 }
 
 // --- Per-list burndown modal ---


### PR DESCRIPTION
Adds a new `renderListCompletionPie` chart showing threshold breakdown
(Finished / Painted / Table Ready / In Progress) scoped to a specific
army list. The chart appears inline on the list detail view in the Armies
screen, and as a full-width grid of per-army pies at the bottom of the
Dashboard — below Recent Activity so existing cards are undisturbed.

https://claude.ai/code/session_01QA9mHbhDBP2ACrBFFnF7A5