### PR TITLE
Fix hobby points not multiplied by model quantity (issue #13)

### DIFF
--- a/js/activity.js
+++ b/js/activity.js
@@ -40,7 +40,7 @@ function renderCalendar(sessions) {
       const model = appData.models[e.modelId];
       if (!model) return acc;
       const stage = (model.stages || appData.config.stages).find(st => st.id === e.stageId);
-      return acc + (stage?.points || 1);
+      return acc + (stage?.points || 1) * (e.qty || 0);
     }, 0);
     byDate[s.date] = (byDate[s.date] || 0) + pts;
   });
@@ -201,7 +201,7 @@ function renderSessionHistory(sessions) {
       return acc + (s.modelEntries || []).reduce((a, e) => {
         const model = appData.models[e.modelId];
         const stage = (model?.stages || appData.config.stages).find(st => st.id === e.stageId);
-        return a + (stage?.points || 1);
+        return a + (stage?.points || 1) * (e.qty || 0);
       }, 0);
     }, 0);
 

--- a/js/dashboard.js
+++ b/js/dashboard.js
@@ -145,7 +145,7 @@ function renderWeeklySummary() {
     return acc + (s.modelEntries || []).reduce((a, e) => {
       const model = appData.models[e.modelId];
       const stage = (model?.stages || appData.config.stages).find(st => st.id === e.stageId);
-      return a + (stage?.points || 1);
+      return a + (stage?.points || 1) * (e.qty || 0);
     }, 0);
   }, 0);
 


### PR DESCRIPTION
Points per stage are defined per model, so all three activity aggregations
(weekly summary, calendar heatmap, monthly history) must multiply stage points
by the entry's qty field. Without this, recording N models only counted the
base stage points once regardless of quantity.

https://claude.ai/code/session_01BG9k2zTZwtRJPBJkCYbV7c