### PR TITLE
Fix hobby points awarded for total count instead of new items only

### DIFF
--- a/js/models.js
+++ b/js/models.js
@@ -577,7 +577,7 @@ export function showLogProgress(modelId) {
         done = Math.min(parseInt(input?.value) || 0, model.quantity);
       }
       const prev = model.progress[s.id]?.done || 0;
-      if (done !== prev) modelEntries.push({ modelId, stageId: s.id, qty: done });
+      if (done !== prev) modelEntries.push({ modelId, stageId: s.id, qty: done - prev });
       logProgress(modelId, s.id, done, date);
     });
 


### PR DESCRIPTION
When logging activity, store the delta (done - prev) in modelEntries.qty
rather than the absolute completion count. Points in weekly summary and
activity calendar are calculated as qty * stage.points, so previously
logging 3 new basecoated models on top of 9 existing would award points
for all 12 instead of just the 3 new ones.

Fixes #16

https://claude.ai/code/session_015J4Adjc9WBQDT1fqYW6ZR7