### PR TITLE
Add Base64 image compression for model photos

### DIFF
--- a/index.html
+++ b/index.html
@@ -541,6 +541,53 @@
       flex-wrap: wrap;
     }
 
+    .model-card-thumb {
+      display: block;
+      width: calc(100% + 1.8em);
+      height: 72px;
+      object-fit: cover;
+      margin: -0.9em -0.9em 0.75em -0.9em;
+      border-radius: calc(var(--radius) - 1px) calc(var(--radius) - 1px) 0 0;
+    }
+
+    .detail-image {
+      display: block;
+      width: 100%;
+      max-height: 220px;
+      object-fit: contain;
+      border-radius: var(--radius);
+      background: var(--surface2);
+      margin-bottom: 0.75em;
+    }
+
+    .img-upload-area {
+      background: var(--surface2);
+      border: 1px dashed var(--border);
+      border-radius: var(--radius);
+      overflow: hidden;
+      margin-bottom: 0.5em;
+      min-height: 72px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+    }
+
+    .img-upload-preview {
+      display: block;
+      width: 100%;
+      max-height: 160px;
+      object-fit: contain;
+    }
+
+    .img-upload-placeholder {
+      color: var(--text-muted);
+      font-size: 0.85em;
+      padding: 1em;
+    }
+
+    .img-upload-actions { display: flex; gap: 0.5em; margin-bottom: 0.3em; }
+    .img-upload-info { font-size: 0.75em; color: var(--text-muted); }
+
     /* ================================================================
        STAGE ROWS
     ================================================================ */

--- a/js/data.js
+++ b/js/data.js
@@ -281,11 +281,11 @@ export function getModel(id) { return appData.models[id]; }
 
 export function getAllModels() { return Object.values(appData.models); }
 
-export function createModel({ name, quantity = 1, notes = '', gameSystemId = null, stages = null, skippedStages = [], folderId = null }) {
+export function createModel({ name, quantity = 1, notes = '', gameSystemId = null, stages = null, skippedStages = [], folderId = null, image = null }) {
   const id = uid();
   const modelStages = stages || appData.config.stages.map(s => ({ ...s }));
   appData.models[id] = {
-    id, name, quantity, notes, gameSystemId, folderId,
+    id, name, quantity, notes, gameSystemId, folderId, image,
     stages: modelStages,
     skippedStages,
     progress: {},

--- a/js/imageUtils.js
+++ b/js/imageUtils.js
@@ -1,0 +1,24 @@
+// imageUtils.js — browser-side image compression to Base64 thumbnail
+
+export function compressImageToBase64(file, maxDim = 128, quality = 0.65) {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onerror = reject;
+    reader.onload = e => {
+      const img = new Image();
+      img.onerror = reject;
+      img.onload = () => {
+        let { width: w, height: h } = img;
+        if (w > h) { if (w > maxDim) { h = Math.round(h * maxDim / w); w = maxDim; } }
+        else        { if (h > maxDim) { w = Math.round(w * maxDim / h); h = maxDim; } }
+        const canvas = document.createElement('canvas');
+        canvas.width = w;
+        canvas.height = h;
+        canvas.getContext('2d').drawImage(img, 0, 0, w, h);
+        resolve(canvas.toDataURL('image/jpeg', quality));
+      };
+      img.src = e.target.result;
+    };
+    reader.readAsDataURL(file);
+  });
+}

--- a/js/models.js
+++ b/js/models.js
@@ -8,6 +8,7 @@ import {
 } from './data.js';
 import { showModal, closeModal, toast, progressBar, thresholdBadge, stageRow, today, createDateInput, getDateValue } from './ui.js';
 import { getTerm } from './theme.js';
+import { compressImageToBase64 } from './imageUtils.js';
 
 // Lazy import to avoid circular dependency
 async function pruneQueues() {
@@ -166,6 +167,7 @@ function modelCard(model) {
 
   return `
     <div class="model-card" data-model-view="${model.id}">
+      ${model.image ? `<img class="model-card-thumb" src="${model.image}" alt="">` : ''}
       <div class="model-card-header">
         <div>
           <div class="model-card-name">${model.name}</div>
@@ -201,6 +203,7 @@ export function showModelDetail(modelId) {
 
   const content = document.createElement('div');
   content.innerHTML = `
+    ${model.image ? `<img class="detail-image" src="${model.image}" alt="${model.name}">` : ''}
     <div class="detail-header">
       <div>
         <div class="detail-qty">Quantity: <b>${model.quantity}</b></div>
@@ -239,6 +242,7 @@ export function showModelForm(editId = null, defaultFolderId = null) {
   const allTypes = getAllModelTypes();
   const folders = getAllFolders();
   const currentFolderId = model?.folderId || defaultFolderId || '';
+  let currentImage = model?.image || null;
 
   const content = document.createElement('div');
   content.innerHTML = `
@@ -263,6 +267,21 @@ export function showModelForm(editId = null, defaultFolderId = null) {
     <div class="form-group">
       <label>Notes (optional)</label>
       <textarea id="mfNotes" class="form-input" rows="2">${model?.notes || ''}</textarea>
+    </div>
+    <div class="form-group">
+      <label>Photo (optional)</label>
+      <div class="img-upload-area" id="mfImageArea">
+        ${currentImage
+          ? `<img class="img-upload-preview" id="mfImagePreview" src="${currentImage}" alt="">`
+          : `<div class="img-upload-placeholder" id="mfImagePlaceholder">📷 No photo yet</div>`
+        }
+      </div>
+      <div class="img-upload-actions">
+        <button class="btn btn-sm" id="mfImageBtn" type="button">📷 Choose Photo</button>
+        <button class="btn btn-sm btn-danger" id="mfImageRemove" type="button" style="${currentImage ? '' : 'display:none'}">✕ Remove</button>
+      </div>
+      <input type="file" id="mfImageInput" accept="image/*" style="display:none">
+      <div class="img-upload-info" id="mfImageInfo"></div>
     </div>
     <div class="form-group">
       <label>Model Type</label>
@@ -306,6 +325,37 @@ export function showModelForm(editId = null, defaultFolderId = null) {
         e.target.value = currentFolderId || '';
       }
     }
+  });
+
+  // Image upload
+  content.querySelector('#mfImageBtn').addEventListener('click', () => {
+    content.querySelector('#mfImageInput').click();
+  });
+
+  content.querySelector('#mfImageInput').addEventListener('change', async e => {
+    const file = e.target.files[0];
+    if (!file) return;
+    const infoEl = content.querySelector('#mfImageInfo');
+    infoEl.textContent = 'Compressing…';
+    try {
+      const dataUrl = await compressImageToBase64(file, 128, 0.65);
+      currentImage = dataUrl;
+      const area = content.querySelector('#mfImageArea');
+      area.innerHTML = `<img class="img-upload-preview" id="mfImagePreview" src="${dataUrl}" alt="">`;
+      content.querySelector('#mfImageRemove').style.display = '';
+      const kb = Math.round(dataUrl.length * 0.75 / 1024);
+      infoEl.textContent = `Thumbnail: ~${kb} KB stored`;
+    } catch {
+      infoEl.textContent = 'Failed to process image.';
+    }
+    e.target.value = '';
+  });
+
+  content.querySelector('#mfImageRemove').addEventListener('click', () => {
+    currentImage = null;
+    content.querySelector('#mfImageArea').innerHTML = `<div class="img-upload-placeholder" id="mfImagePlaceholder">📷 No photo yet</div>`;
+    content.querySelector('#mfImageRemove').style.display = 'none';
+    content.querySelector('#mfImageInfo').textContent = '';
   });
 
   // Preset dropdown
@@ -363,10 +413,10 @@ export function showModelForm(editId = null, defaultFolderId = null) {
     const { stages: newStages, skipped: newSkipped } = collectStagesAndSkipped(content);
 
     if (editId) {
-      updateModel(editId, { name, quantity, notes, modelTypeId, folderId, stages: newStages, skippedStages: newSkipped });
+      updateModel(editId, { name, quantity, notes, modelTypeId, folderId, stages: newStages, skippedStages: newSkipped, image: currentImage });
       toast('Updated!', 'success');
     } else {
-      createModel({ name, quantity, notes, modelTypeId, folderId, stages: newStages, skippedStages: newSkipped });
+      createModel({ name, quantity, notes, modelTypeId, folderId, stages: newStages, skippedStages: newSkipped, image: currentImage });
       toast(`${getTerm('model')} added!`, 'success');
     }
 


### PR DESCRIPTION
Adds photo upload to the model form: user picks an image, it is
compressed to a 128px thumbnail via Canvas (JPEG q0.65, ~2-3 KB),
stored as a Base64 data URI on the model object in localStorage.
Thumbnails appear as a banner on model cards and full-width in the
detail modal. Remove button clears the stored image.

https://claude.ai/code/session_01KZ9Vf8Q5HWxb2VWxKJjyrc