### PR TITLE
Add configurable photo quality and localStorage usage indicator

### DIFF
--- a/index.html
+++ b/index.html
@@ -588,6 +588,22 @@
     .img-upload-actions { display: flex; gap: 0.5em; margin-bottom: 0.3em; }
     .img-upload-info { font-size: 0.75em; color: var(--text-muted); }
 
+    .storage-bar-wrap {
+      background: var(--surface2);
+      border: 1px solid var(--border);
+      border-radius: 4px;
+      height: 8px;
+      overflow: hidden;
+      margin: 0.3em 0 0.2em;
+    }
+    .storage-bar {
+      height: 100%;
+      background: var(--accent);
+      border-radius: 4px;
+      transition: width 0.3s;
+      min-width: 2px;
+    }
+
     /* ================================================================
        STAGE ROWS
     ================================================================ */
@@ -1886,7 +1902,41 @@
         ` : '<p class="empty-text" style="padding:0.5em 0">No custom types yet. Save one from the Add Model form.</p>'}
       </div>
       <div class="settings-section">
+        <h3>Photos</h3>
+        <div class="settings-row">
+          <div>
+            <div class="settings-row-label">Thumbnail quality</div>
+            <div class="settings-row-desc">Applied when you upload a new photo. Existing photos are unaffected.</div>
+          </div>
+          <select class="form-input" id="imageSizeSelect" style="width:auto">
+            <option value="small"  ${(appData.config.imageSize || 'small') === 'small'  ? 'selected' : ''}>Small (~3 KB)</option>
+            <option value="medium" ${appData.config.imageSize === 'medium' ? 'selected' : ''}>Medium (~9 KB)</option>
+            <option value="large"  ${appData.config.imageSize === 'large'  ? 'selected' : ''}>Large (~30 KB)</option>
+          </select>
+        </div>
+      </div>
+      <div class="settings-section">
         <h3>Data Management</h3>
+        <div class="settings-row" style="flex-direction:column;align-items:stretch;gap:0.4em">
+          <div class="settings-row-label">Storage used</div>
+          ${(() => {
+            let used = 0;
+            for (const key in localStorage) {
+              if (Object.prototype.hasOwnProperty.call(localStorage, key)) {
+                used += (localStorage[key].length + key.length) * 2;
+              }
+            }
+            const limit = 5 * 1024 * 1024;
+            const pct = Math.min(100, Math.round(used / limit * 100));
+            const usedKB = (used / 1024).toFixed(0);
+            return `
+              <div class="storage-bar-wrap">
+                <div class="storage-bar" style="width:${pct}%"></div>
+              </div>
+              <div class="settings-row-desc">${usedKB} KB of ~5 MB used (${pct}%)</div>
+            `;
+          })()}
+        </div>
         <div class="settings-row">
           <div>
             <div class="settings-row-label">Export Data</div>
@@ -1929,6 +1979,12 @@
     container.querySelector('#themeSelect')?.addEventListener('change', e => {
       applyTheme(e.target.value);
       toast('Theme saved!', 'success');
+    });
+
+    container.querySelector('#imageSizeSelect')?.addEventListener('change', e => {
+      appData.config.imageSize = e.target.value;
+      saveData();
+      toast('Photo quality saved!', 'success');
     });
 
     container.querySelectorAll('[data-delete-type]').forEach(btn => {

--- a/js/data.js
+++ b/js/data.js
@@ -202,7 +202,8 @@ export let appData = {
     deadline: null,
     activeTheme: 'theme-default',
     modelTypes: [],
-    weeklyGoal: 0
+    weeklyGoal: 0,
+    imageSize: 'small'
   },
   folders: {}, // id -> { id, name, collapsed }
   queues: {}   // id -> { id, name, entries: [{id, modelId, note}] }
@@ -248,7 +249,8 @@ export function loadData() {
           deadline: parsed.config?.deadline || null,
           activeTheme: parsed.config?.activeTheme || 'theme-default',
           modelTypes: parsed.config?.modelTypes || [],
-          weeklyGoal: parsed.config?.weeklyGoal || 0
+          weeklyGoal: parsed.config?.weeklyGoal || 0,
+          imageSize: parsed.config?.imageSize || 'small'
         }
       };
     }

--- a/js/imageUtils.js
+++ b/js/imageUtils.js
@@ -1,5 +1,11 @@
 // imageUtils.js — browser-side image compression to Base64 thumbnail
 
+export const IMAGE_SIZE_PRESETS = {
+  small:  { maxDim: 128, quality: 0.65, label: 'Small  (~3 KB)' },
+  medium: { maxDim: 384, quality: 0.75, label: 'Medium (~9 KB)' },
+  large:  { maxDim: 640, quality: 0.80, label: 'Large  (~30 KB)' },
+};
+
 export function compressImageToBase64(file, maxDim = 128, quality = 0.65) {
   return new Promise((resolve, reject) => {
     const reader = new FileReader();

--- a/js/models.js
+++ b/js/models.js
@@ -8,7 +8,7 @@ import {
 } from './data.js';
 import { showModal, closeModal, toast, progressBar, thresholdBadge, stageRow, today, createDateInput, getDateValue } from './ui.js';
 import { getTerm } from './theme.js';
-import { compressImageToBase64 } from './imageUtils.js';
+import { compressImageToBase64, IMAGE_SIZE_PRESETS } from './imageUtils.js';
 
 // Lazy import to avoid circular dependency
 async function pruneQueues() {
@@ -338,7 +338,8 @@ export function showModelForm(editId = null, defaultFolderId = null) {
     const infoEl = content.querySelector('#mfImageInfo');
     infoEl.textContent = 'Compressing…';
     try {
-      const dataUrl = await compressImageToBase64(file, 128, 0.65);
+      const preset = IMAGE_SIZE_PRESETS[appData.config.imageSize || 'small'];
+      const dataUrl = await compressImageToBase64(file, preset.maxDim, preset.quality);
       currentImage = dataUrl;
       const area = content.querySelector('#mfImageArea');
       area.innerHTML = `<img class="img-upload-preview" id="mfImagePreview" src="${dataUrl}" alt="">`;


### PR DESCRIPTION
Settings > Photos: Small/Medium/Large presets (128px/384px/640px, ~3/9/30 KB). New photos use the selected preset; existing images are unaffected. Settings > Data Management: storage bar shows approximate KB used vs ~5 MB limit.

https://claude.ai/code/session_01KZ9Vf8Q5HWxb2VWxKJjyrc