### PR TITLE
7 UX improvements: onboarding, type groups, army discoverability, log…

### DIFF
--- a/index.html
+++ b/index.html
@@ -1056,6 +1056,59 @@
     .empty-state p { margin-bottom: 1em; font-size: 0.95em; }
     .empty-text { font-size: 0.85em; color: var(--text-muted); font-style: italic; }
 
+    /* Onboarding card (first-run empty states) */
+    .onboarding-card {
+      max-width: 520px;
+      margin: 2em auto;
+      background: var(--surface);
+      border: 1px solid var(--border);
+      border-radius: 12px;
+      padding: 2em 1.75em;
+    }
+    .onboarding-title { font-family: var(--font-display); font-size: 1.3em; margin-bottom: 0.5em; }
+    .onboarding-desc { color: var(--text-muted); font-size: 0.9em; margin-bottom: 1.25em; }
+    .onboarding-steps { display: flex; flex-direction: column; gap: 1em; margin-bottom: 1.5em; }
+    .onboarding-step { display: flex; gap: 0.9em; align-items: flex-start; }
+    .onboarding-step .step-num {
+      flex-shrink: 0;
+      width: 1.6em; height: 1.6em;
+      border-radius: 50%;
+      background: var(--accent);
+      color: #fff;
+      display: flex; align-items: center; justify-content: center;
+      font-size: 0.8em; font-weight: bold;
+    }
+    .onboarding-step div { line-height: 1.4; }
+    .onboarding-step b { display: block; margin-bottom: 0.15em; }
+    .onboarding-step p { margin: 0; font-size: 0.85em; color: var(--text-muted); }
+    .onboarding-cta { margin-top: 0.5em; }
+
+    /* Army nudge banner */
+    .army-nudge {
+      display: flex; align-items: center; gap: 0.75em;
+      background: var(--surface);
+      border: 1px solid var(--accent);
+      border-radius: 8px;
+      padding: 0.7em 1em;
+      margin-bottom: 1em;
+      font-size: 0.88em;
+    }
+    .army-nudge-icon { font-size: 1.3em; flex-shrink: 0; }
+    .army-nudge-body { flex: 1; line-height: 1.4; }
+    .army-nudge-body b { display: block; margin-bottom: 0.1em; }
+    .army-nudge-body span { color: var(--text-muted); }
+
+    /* Stage done indicator in Log Progress */
+    .stage-done { opacity: 0.55; }
+    .stage-done-badge { font-size: 0.78em; color: var(--accent); font-weight: bold; margin-left: 0.3em; }
+
+    /* Weekly goal nudge */
+    .weekly-goal-nudge { margin-bottom: 0.5em; }
+    .goal-nudge-text { font-size: 0.82em; color: var(--text-muted); margin-bottom: 0.5em; }
+
+    /* Log time hint */
+    .log-time-hint { margin-top: 0.25em; }
+
     /* ================================================================
        SETTINGS PANEL
     ================================================================ */

--- a/js/collections.js
+++ b/js/collections.js
@@ -19,9 +19,33 @@ export function renderCollections() {
   const collections = Object.values(appData.collections);
   if (!collections.length) {
     container.innerHTML = `
-      <div class="empty-state">
-        <p>No game systems yet. Add one to get started.</p>
-        <button class="btn btn-primary" id="addFirstCollection">+ Add Game System</button>
+      <div class="onboarding-card">
+        <div class="onboarding-title">🛡️ Army Lists</div>
+        <p class="onboarding-desc">Army lists let you group models from your pool into specific projects — a tournament force, a painting batch — and track them toward a deadline.</p>
+        <div class="onboarding-steps">
+          <div class="onboarding-step">
+            <span class="step-num">1</span>
+            <div>
+              <b>Create a Game System</b>
+              <p>Choose the game you're painting for — Old World, 40K, Age of Sigmar, or custom.</p>
+            </div>
+          </div>
+          <div class="onboarding-step">
+            <span class="step-num">2</span>
+            <div>
+              <b>Add an Army List</b>
+              <p>Name your project (e.g. "Tournament Army" or "February batch") and optionally set a target date.</p>
+            </div>
+          </div>
+          <div class="onboarding-step">
+            <span class="step-num">3</span>
+            <div>
+              <b>Add models from your pool</b>
+              <p>Pick which models belong to this list — their progress tracks together and appears on the Dashboard.</p>
+            </div>
+          </div>
+        </div>
+        <button class="btn btn-primary onboarding-cta" id="addFirstCollection">+ Create First Game System</button>
       </div>`;
     document.getElementById('addFirstCollection')?.addEventListener('click', () => showCollectionForm());
     return;

--- a/js/dashboard.js
+++ b/js/dashboard.js
@@ -216,8 +216,9 @@ function renderWeeklySummary() {
         </div>
       </div>
     ` : `
-      <div class="weekly-goal-set">
-        <button class="btn btn-sm" id="setWeeklyGoalBtn">🎯 Set weekly goal</button>
+      <div class="weekly-goal-nudge">
+        <p class="goal-nudge-text">Set a weekly painting goal to track your pace and get encouragement messages.</p>
+        <button class="btn btn-sm btn-primary" id="setWeeklyGoalBtn">🎯 Set weekly goal</button>
       </div>
     `}
     <div class="weekly-message">${message}</div>

--- a/js/models.js
+++ b/js/models.js
@@ -28,10 +28,36 @@ export function renderModelPool(containerId = 'modelPool') {
   const folders = getAllFolders();
 
   if (!allModels.length && !folders.length) {
-    container.innerHTML = `<div class="empty-state">
-      <p>No ${getTerm('model')}s in your collection yet.</p>
-      <p style="font-size:0.85em;color:var(--text-muted)">Use the + button to add your first model.</p>
-    </div>`;
+    container.innerHTML = `
+      <div class="onboarding-card">
+        <div class="onboarding-title">👋 Welcome to Hobby Manager!</div>
+        <p class="onboarding-desc">Track your miniature painting progress from sprue to finished model.</p>
+        <div class="onboarding-steps">
+          <div class="onboarding-step">
+            <span class="step-num">1</span>
+            <div>
+              <b>Add your models</b>
+              <p>Tap <b>+</b> above to add models to your collection. Choose a type — Infantry, Cavalry, Behemoth — and set how many you have.</p>
+            </div>
+          </div>
+          <div class="onboarding-step">
+            <span class="step-num">2</span>
+            <div>
+              <b>Build an army list</b>
+              <p>Head to the <b>🛡️ Armies</b> tab to create a game system and army list, then pull your models in from this pool.</p>
+            </div>
+          </div>
+          <div class="onboarding-step">
+            <span class="step-num">3</span>
+            <div>
+              <b>Log your sessions</b>
+              <p>Hit <b>📝 Log</b> on any model card to record which painting stages you've completed. Progress shows on the Dashboard.</p>
+            </div>
+          </div>
+        </div>
+        <button class="btn btn-primary onboarding-cta" id="onboardingAddBtn">+ Add your first model</button>
+      </div>`;
+    container.querySelector('#onboardingAddBtn').addEventListener('click', () => showModelForm());
     return;
   }
 
@@ -47,6 +73,7 @@ export function renderModelPool(containerId = 'modelPool') {
     }
   });
 
+  const hasLists = Object.keys(appData.lists || {}).length > 0;
   let html = '';
 
   // Render each folder
@@ -99,7 +126,22 @@ export function renderModelPool(containerId = 'modelPool') {
     html = `<div class="empty-state"><p>No models yet. Use the + button to add one.</p></div>`;
   }
 
+  if (!hasLists) {
+    html = `<div class="army-nudge">
+      <span class="army-nudge-icon">🛡️</span>
+      <div class="army-nudge-body">
+        <b>Organise into army lists</b>
+        <span>Head to the Armies tab to group these models into a project and track progress toward a deadline.</span>
+      </div>
+      <button class="btn btn-sm btn-primary" id="nudgeArmiesBtn">Armies →</button>
+    </div>` + html;
+  }
+
   container.innerHTML = html;
+
+  container.querySelector('#nudgeArmiesBtn')?.addEventListener('click', () => {
+    document.querySelector('.nav-tab[data-tab="collections"]')?.click();
+  });
 
   // Folder toggle collapse
   container.querySelectorAll('[data-toggle-folder]').forEach(btn => {
@@ -234,6 +276,39 @@ export function showModelDetail(modelId) {
 
 // --- Model form (create / edit) ---
 
+const TYPE_GROUPS = {
+  'Infantry-scale': ['infantry', 'swarm'],
+  'Mounted':        ['cavalry', 'monstrous_cavalry', 'jetbike', 'chariot'],
+  'Large':          ['monster', 'walker', 'behemoth'],
+  'Characters':     ['character', 'character_horse', 'character_monster'],
+  'Vehicles':       ['warmachine', 'vehicle'],
+  'Special':        ['terrain'],
+};
+
+function renderTypeOptions(allTypes, selectedId) {
+  const builtIn = allTypes.filter(t => t.builtIn);
+  const custom = allTypes.filter(t => !t.builtIn);
+  const grouped = Object.values(TYPE_GROUPS).flat();
+  let html = '';
+  for (const [group, ids] of Object.entries(TYPE_GROUPS)) {
+    const types = builtIn.filter(t => ids.includes(t.id));
+    if (!types.length) continue;
+    html += `<optgroup label="${group}">${types.map(t =>
+      `<option value="${t.id}" ${selectedId === t.id ? 'selected' : ''}>${t.name}</option>`
+    ).join('')}</optgroup>`;
+  }
+  const ungrouped = builtIn.filter(t => !grouped.includes(t.id));
+  if (ungrouped.length) html += ungrouped.map(t =>
+    `<option value="${t.id}" ${selectedId === t.id ? 'selected' : ''}>${t.name}</option>`
+  ).join('');
+  if (custom.length) {
+    html += `<optgroup label="Custom ⭐">${custom.map(t =>
+      `<option value="${t.id}" ${selectedId === t.id ? 'selected' : ''}>${t.name}</option>`
+    ).join('')}</optgroup>`;
+  }
+  return html;
+}
+
 export function showModelForm(editId = null, defaultFolderId = null) {
   editId = editId || null;
   const model = editId ? appData.models[editId] : null;
@@ -294,7 +369,7 @@ export function showModelForm(editId = null, defaultFolderId = null) {
       <label>Model Type</label>
       <select id="mfTypeSelect" class="form-input">
         <option value="">— Custom / Manual —</option>
-        ${allTypes.map(t => `<option value="${t.id}" ${effectiveTypeId === t.id ? 'selected' : ''}>${t.name}${t.builtIn ? '' : ' ⭐'}</option>`).join('')}
+        ${renderTypeOptions(allTypes, effectiveTypeId)}
       </select>
       <div class="model-type-manage" id="mfTypeManage"></div>
     </div>
@@ -559,7 +634,8 @@ export function showLogProgress(modelId) {
       </div>
       <div class="form-group">
         <label>Time spent (mins)</label>
-        <input id="lpDuration" type="number" class="form-input" min="0" placeholder="e.g. 90">
+        <input id="lpDuration" type="number" class="form-input" min="0" placeholder="e.g. 45">
+        <div class="form-hint log-time-hint">If left blank, logged as historical activity.</div>
       </div>
     </div>
     <div class="form-group">
@@ -581,8 +657,8 @@ export function showLogProgress(modelId) {
             `;
           }
           return `
-            <div class="log-stage-row">
-              <div class="log-stage-name">${s.name}</div>
+            <div class="log-stage-row${isDone ? ' stage-done' : ''}">
+              <div class="log-stage-name">${s.name}${isDone ? ' <span class="stage-done-badge">✓</span>' : ''}</div>
               <div class="log-stage-input">
                 <button class="btn btn-sm qty-dec" data-sid="${s.id}">−</button>
                 <input type="number" class="form-input qty-input" id="lp_${s.id}"
@@ -631,6 +707,7 @@ export function showLogProgress(modelId) {
 
   // Reset All — zero everything out
   content.querySelector('#lpReset').addEventListener('click', () => {
+    if (!confirm('Reset all stage progress to zero? This cannot be undone.')) return;
     if (isSingle) {
       content.querySelectorAll('.stage-checkbox').forEach(cb => {
         cb.checked = false;
@@ -645,7 +722,9 @@ export function showLogProgress(modelId) {
 
   content.querySelector('#lpSave').addEventListener('click', () => {
     const date = getDateValue('lpDate');
-    const duration = parseInt(content.querySelector('#lpDuration').value) || null;
+    const rawDuration = content.querySelector('#lpDuration').value;
+    const duration = rawDuration ? (parseInt(rawDuration) || null) : null;
+    if (!duration && !confirm('No time entered — this will be recorded as historical activity with no session time. Log anyway?')) return;
 
     const modelEntries = [];
     stages.forEach(s => {


### PR DESCRIPTION
… guards

1. Type dropdown now uses <optgroup> headings (Infantry-scale / Mounted / Large / Characters / Vehicles / Special) — 15 types are now navigable.

2. First-run empty state on Models tab replaced with a 3-step onboarding card explaining the add → army list → log workflow.

3. Armies tab empty state similarly replaced with a guided onboarding card explaining game systems → army lists → adding from pool.

4. Army discoverability nudge: when models exist but no army lists, a banner appears at the top of the Models tab with an 'Armies →' button that switches directly to the Armies tab.

5. Completed stages in Log Progress (multi-model): fully-done stages show a muted ✓ badge so users can see at a glance what's already tracked.

6. Log Progress time field: placeholder 'e.g. 45', hint text explaining blank = historical activity, and a confirm prompt when saving with no time entered.

7. 'Reset All' in Log Progress now requires confirmation before zeroing out all stage progress.

Also: weekly goal nudge on Dashboard gains explanatory text and is styled as a primary button to improve discoverability.

https://claude.ai/code/session_01X5p7w2QhhxvNVKd16euXjw