### PR TITLE
Fix OWB parser treating rune upgrades as sub-units

### DIFF
--- a/js/owb-import.js
+++ b/js/owb-import.js
@@ -27,7 +27,7 @@ function detectModelType(name, section) {
   if (s.includes('character') || s.includes('lord') || s.includes('hero')) return 'character';
 
   if (/chariot/.test(n)) return 'chariot';
-  if (/war machine|cannon|bolt thrower|mortar|catapult|rocket|stone thrower|organ gun/.test(n)) return 'warmachine';
+  if (/war machine|cannon|bolt thrower|mortar|catapult|rocket|stone thrower|organ gun|gyrocopter|gyrobomber|flame cannon/.test(n)) return 'warmachine';
   if (/cavalry|knights?|horsemen|riders?|lancers?/.test(n)) return 'cavalry';
   if (/dragon|hydra|manticore|giant|wyvern|griffon|sphinx|hippogryph|cockatrice|abomination|bone giant|rat ogre|ogre|troll|minotaur/.test(n)) return 'monster';
   if (/swarm/.test(n)) return 'swarm';
@@ -80,8 +80,9 @@ export function parseOwbList(text) {
       continue;
     }
 
-    // Sub-unit option line: "- Nx Name [...]"
-    const subUnitMatch = line.match(/^-\s+(\d+)x\s+(.+?)(?:\s*\[.*\])?$/);
+    // Sub-unit option line: "- Nx Name [equipment]"
+    // Must have a non-empty [...] block to distinguish from upgrade lines like "- 2x Rune of Shielding"
+    const subUnitMatch = line.match(/^-\s+(\d+)x\s+(.+?)\s+\[.+\]$/);
     if (subUnitMatch) {
       const qty = parseInt(subUnitMatch[1], 10);
       const name = subUnitMatch[2].trim();
@@ -89,14 +90,15 @@ export function parseOwbList(text) {
       continue;
     }
 
-    // Other option/upgrade lines — skip
+    // All other option/upgrade lines (including "- 2x Rune of X", "- Shield", etc.) — skip
     if (line.startsWith('-')) continue;
 
     // Unit with explicit quantity: "N Name [pts]"
+    // Strip trailing OWB constraint annotations like "(0-3 warmachines per 1000 points)"
     const unitQtyMatch = line.match(/^(\d+)\s+(.+?)\s+\[\d+\s*pts?\]$/);
     if (unitQtyMatch) {
       const qty = parseInt(unitQtyMatch[1], 10);
-      const name = unitQtyMatch[2].trim();
+      const name = unitQtyMatch[2].replace(/\s*\(0-\d+[^)]*\)\s*$/, '').trim();
       units.push({ name, quantity: qty, section: currentSection, modelTypeId: detectModelType(name, currentSection) });
       continue;
     }


### PR DESCRIPTION
The sub-unit regex now requires a non-empty [...] equipment block, which is only present on genuine sub-entries like Weapon Teams. Plain upgrade lines like "- 2x Rune of Shielding" no longer match. Also strips OWB constraint annotations (0-N ...) from unit names, and adds gyrocopter/gyrobomber/flame cannon to war machine keywords.

https://claude.ai/code/session_01VNLz1eSV4JBNkASYtPhU7S