### PR TITLE
Add configurable templates for standard model types

### DIFF
--- a/index.html
+++ b/index.html
@@ -1143,6 +1143,18 @@
     .settings-row:last-child { border-bottom: none; }
     .settings-row-label { font-size: 0.9em; }
     .settings-row-desc { font-size: 0.78em; color: var(--text-muted); }
+    .type-customised-badge {
+      display: inline-block;
+      font-size: 0.7em;
+      padding: 1px 6px;
+      border-radius: 4px;
+      background: var(--accent-dim, #1a2e20);
+      color: var(--accent, #4a9d6f);
+      border: 1px solid var(--accent, #4a9d6f44);
+      vertical-align: middle;
+      margin-left: 0.4em;
+      font-weight: normal;
+    }
 
     .model-type-row {
       display: flex;
@@ -1842,8 +1854,8 @@
 </div>
 
 <script type="module">
-  import { loadData, exportJSON, importJSON, appData, getAllModelTypes, deleteCustomModelType, createFolder } from './js/data.js';
-  import { renderModelPool, showModelForm } from './js/models.js';
+  import { loadData, exportJSON, importJSON, appData, getAllModelTypes, deleteCustomModelType, BUILTIN_MODEL_TYPES, createFolder } from './js/data.js';
+  import { renderModelPool, showModelForm, showModelTypeEditor } from './js/models.js';
   import { renderCollections } from './js/collections.js';
   import { renderDashboard } from './js/dashboard.js';
   import { renderQueues } from './js/queue.js';
@@ -1940,6 +1952,27 @@
             <option value="theme-heresy" ${appData.config.activeTheme === 'theme-heresy' ? 'selected' : ''}>🔱 Horus Heresy</option>
             <option value="theme-aos" ${appData.config.activeTheme === 'theme-aos' ? 'selected' : ''}>✨ Age of Sigmar</option>
           </select>
+        </div>
+      </div>
+      <div class="settings-section">
+        <h3>Standard Model Type Templates</h3>
+        <p class="settings-row-desc" style="margin-bottom:0.75em">Edit the default stages and hobby points for each built-in model type. New models of that type will use your settings; existing models are unaffected.</p>
+        <div class="custom-types-list">
+          ${BUILTIN_MODEL_TYPES.map(t => {
+            const overrides = appData.config.modelTypeOverrides || {};
+            const effectiveStages = overrides[t.id] ? overrides[t.id] : t.stages;
+            const totalPts = effectiveStages.reduce((a, s) => a + s.points, 0);
+            const isCustomised = !!overrides[t.id];
+            return `
+              <div class="settings-row">
+                <div>
+                  <div class="settings-row-label">${t.name}${isCustomised ? ' <span class="type-customised-badge">customised</span>' : ''}</div>
+                  <div class="settings-row-desc">${effectiveStages.length} stages · ${totalPts} total pts</div>
+                </div>
+                <button class="btn btn-sm" data-edit-builtin="${t.id}">✏️ Edit</button>
+              </div>
+            `;
+          }).join('')}
         </div>
       </div>
       <div class="settings-section">
@@ -2042,6 +2075,12 @@
       appData.config.imageSize = e.target.value;
       saveData();
       toast('Photo quality saved!', 'success');
+    });
+
+    container.querySelectorAll('[data-edit-builtin]').forEach(btn => {
+      btn.addEventListener('click', () => {
+        showModelTypeEditor(btn.dataset.editBuiltin, () => renderSettings());
+      });
     });
 
     container.querySelectorAll('[data-delete-type]').forEach(btn => {

--- a/js/data.js
+++ b/js/data.js
@@ -272,14 +272,30 @@ export const BUILTIN_MODEL_TYPES = [
   },
 ];
 
-// Get all model types (built-in + custom)
+// Get all model types (built-in + custom), applying any user overrides to built-in stages
 export function getAllModelTypes() {
+  const overrides = appData.config.modelTypeOverrides || {};
   const custom = appData.config.modelTypes || [];
-  return [...BUILTIN_MODEL_TYPES, ...custom];
+  const builtIn = BUILTIN_MODEL_TYPES.map(t =>
+    overrides[t.id] ? { ...t, stages: overrides[t.id] } : t
+  );
+  return [...builtIn, ...custom];
 }
 
 export function getModelType(id) {
   return getAllModelTypes().find(t => t.id === id) || null;
+}
+
+export function saveModelTypeOverride(typeId, stages) {
+  if (!appData.config.modelTypeOverrides) appData.config.modelTypeOverrides = {};
+  appData.config.modelTypeOverrides[typeId] = stages;
+  saveData();
+}
+
+export function resetModelTypeOverride(typeId) {
+  if (!appData.config.modelTypeOverrides) return;
+  delete appData.config.modelTypeOverrides[typeId];
+  saveData();
 }
 
 export function saveCustomModelType(typeObj) {
@@ -321,6 +337,7 @@ export let appData = {
     deadline: null,
     activeTheme: 'theme-default',
     modelTypes: [],
+    modelTypeOverrides: {},
     weeklyGoal: 0,
     imageSize: 'small'
   },
@@ -368,6 +385,7 @@ export function loadData() {
           deadline: parsed.config?.deadline || null,
           activeTheme: parsed.config?.activeTheme || 'theme-default',
           modelTypes: parsed.config?.modelTypes || [],
+          modelTypeOverrides: parsed.config?.modelTypeOverrides || {},
           weeklyGoal: parsed.config?.weeklyGoal || 0,
           imageSize: parsed.config?.imageSize || 'small'
         }

--- a/js/models.js
+++ b/js/models.js
@@ -4,6 +4,7 @@ import {
   appData, createModel, updateModel, deleteModel,
   logProgress, logSession, modelPoints, modelThreshold, uid, saveData,
   getAllModelTypes, saveCustomModelType, deleteCustomModelType,
+  saveModelTypeOverride, resetModelTypeOverride, BUILTIN_MODEL_TYPES,
   createFolder, updateFolder, deleteFolder, getAllFolders
 } from './data.js';
 import { showModal, closeModal, toast, progressBar, thresholdBadge, stageRow, today, createDateInput, getDateValue } from './ui.js';
@@ -755,4 +756,121 @@ export function showLogProgress(modelId) {
   content.querySelector('#lpCancel').addEventListener('click', () => closeModal());
 
   showModal({ title: `Log Progress — ${model.name}`, content });
+}
+
+// --- Model type template editor ---
+
+function stageTemplateRow(s) {
+  const milestoneOptions = [
+    { value: '', label: 'None' },
+    { value: 'table_ready', label: '⚔️ Table Ready' },
+    { value: 'painted',     label: '🎨 Painted' },
+    { value: 'finished',    label: '🏆 Finished' },
+  ];
+  return `
+    <div class="stage-config-row" data-sid="${s.id}" data-phase="${s.phase || 'painting'}" data-skippable="${s.skippable ?? true}">
+      <input type="text" class="form-input stage-cfg-name" value="${s.name}" placeholder="Stage name">
+      <input type="number" class="form-input stage-cfg-pts" value="${s.points || 1}" min="0" max="20" title="Hobby points for this stage">
+      <select class="form-input stage-cfg-milestone" title="Milestone this stage completes">
+        ${milestoneOptions.map(o => `<option value="${o.value}" ${(s.threshold || '') === o.value ? 'selected' : ''}>${o.label}</option>`).join('')}
+      </select>
+      <button class="btn btn-xs btn-danger stage-cfg-del" title="Remove stage">✕</button>
+    </div>
+  `;
+}
+
+function collectTemplateStages(container) {
+  const stages = [];
+  container.querySelectorAll('.stage-config-row').forEach(row => {
+    const name = row.querySelector('.stage-cfg-name').value.trim();
+    const pts = parseInt(row.querySelector('.stage-cfg-pts').value) || 1;
+    const threshold = row.querySelector('.stage-cfg-milestone').value || null;
+    if (name) stages.push({
+      id: row.dataset.sid,
+      name,
+      points: pts,
+      threshold,
+      phase: row.dataset.phase || 'painting',
+      skippable: row.dataset.skippable !== 'false'
+    });
+  });
+  return stages;
+}
+
+export function showModelTypeEditor(typeId, onSaved) {
+  const allTypes = getAllModelTypes();
+  const type = allTypes.find(t => t.id === typeId);
+  if (!type) return;
+
+  const isOverridden = !!(appData.config.modelTypeOverrides || {})[typeId];
+  const defaultType = BUILTIN_MODEL_TYPES.find(t => t.id === typeId);
+  const defaultPts = defaultType ? defaultType.stages.reduce((a, s) => a + s.points, 0) : 0;
+
+  const content = document.createElement('div');
+  content.innerHTML = `
+    <p class="form-hint" style="margin-bottom:1em">
+      Changes here set the default stages for all new <b>${type.name}</b> models. Existing models are unaffected.
+    </p>
+    <div class="stages-section-header" style="margin-bottom:0.5em">
+      <span id="metStagesLabel">Stages · <span id="metTotalPts">${type.stages.reduce((a, s) => a + s.points, 0)}</span> total pts</span>
+      <button type="button" class="btn btn-sm" id="metAddStage">+ Add Stage</button>
+    </div>
+    <div id="metStages">
+      ${type.stages.map(s => stageTemplateRow(s)).join('')}
+    </div>
+    <div style="display:flex;gap:0.5em;justify-content:flex-end;margin-top:1em;flex-wrap:wrap">
+      ${isOverridden ? `<button class="btn btn-sm btn-danger" id="metReset">↺ Reset to Default (${defaultPts} pts)</button>` : ''}
+      <button class="btn btn-sm" id="metCancel">Cancel</button>
+      <button class="btn btn-sm btn-primary" id="metSave">Save Template</button>
+    </div>
+  `;
+
+  const stagesContainer = content.querySelector('#metStages');
+  const totalPtsEl = content.querySelector('#metTotalPts');
+
+  function updateTotal() {
+    let total = 0;
+    stagesContainer.querySelectorAll('.stage-cfg-pts').forEach(input => {
+      total += parseInt(input.value) || 0;
+    });
+    totalPtsEl.textContent = total;
+  }
+
+  stagesContainer.addEventListener('input', updateTotal);
+
+  stagesContainer.addEventListener('click', e => {
+    if (e.target.classList.contains('stage-cfg-del')) {
+      e.target.closest('.stage-config-row').remove();
+      updateTotal();
+    }
+  });
+
+  content.querySelector('#metAddStage').addEventListener('click', () => {
+    const s = { id: uid(), name: '', points: 1, phase: 'painting', skippable: true, threshold: null };
+    const row = document.createElement('div');
+    row.innerHTML = stageTemplateRow(s);
+    stagesContainer.appendChild(row.firstElementChild);
+    updateTotal();
+  });
+
+  content.querySelector('#metCancel').addEventListener('click', () => closeModal());
+
+  content.querySelector('#metSave').addEventListener('click', () => {
+    const stages = collectTemplateStages(stagesContainer);
+    if (!stages.length) { toast('Add at least one stage', 'error'); return; }
+    saveModelTypeOverride(typeId, stages);
+    toast(`${type.name} template saved!`, 'success');
+    closeModal();
+    onSaved?.();
+  });
+
+  content.querySelector('#metReset')?.addEventListener('click', () => {
+    if (!confirm(`Reset ${type.name} back to factory defaults?`)) return;
+    resetModelTypeOverride(typeId);
+    toast(`${type.name} reset to defaults`, 'info');
+    closeModal();
+    onSaved?.();
+  });
+
+  showModal({ title: `Edit Template: ${type.name}`, content, wide: true });
 }


### PR DESCRIPTION
Users can now edit the default stages and hobby points for any
built-in model type (Infantry, Cavalry, etc.) from Settings →
Standard Model Type Templates. Changes persist as overrides in
config and are applied when creating new models of that type;
existing models are unaffected. A Reset to Default option restores
factory values, and customised types are labelled in the list.