### PR TITLE
Add OWB import folder selection and mass move to model pool

### DIFF
--- a/index.html
+++ b/index.html
@@ -1667,6 +1667,44 @@
     .folder-unfiled .folder-header { background: var(--bg2); }
 
     /* ================================================================
+       POOL SELECT MODE / MASS MOVE
+    ================================================================ */
+    .pool-select-controls {
+      display: flex;
+      align-items: center;
+      gap: 0.4em;
+      padding: 0.4em 0.5em;
+      margin-bottom: 0.5em;
+    }
+
+    .mass-move-bar {
+      display: flex;
+      align-items: center;
+      gap: 0.5em;
+      padding: 0.5em 0.75em;
+      background: var(--bg2);
+      border: 1px solid var(--accent);
+      border-radius: 8px;
+      margin-bottom: 0.75em;
+      flex-wrap: wrap;
+    }
+    .mass-move-label { font-size: 0.85em; font-weight: 600; white-space: nowrap; }
+    .mass-move-select { flex: 1; min-width: 8em; max-width: 16em; font-size: 0.85em; padding: 0.25em 0.4em; }
+
+    .model-card-selectable {
+      cursor: pointer;
+      user-select: none;
+      position: relative;
+    }
+    .model-card-selectable:hover { border-color: var(--accent); }
+    .model-card-selected { border-color: var(--accent) !important; background: color-mix(in srgb, var(--accent) 12%, var(--bg2)); }
+    .model-select-check {
+      font-size: 1.15em;
+      margin-bottom: 0.2em;
+      color: var(--accent);
+    }
+
+    /* ================================================================
        FLOATING ACTION BUTTON
     ================================================================ */
     .fab {

--- a/js/models.js
+++ b/js/models.js
@@ -11,6 +11,10 @@ import { showModal, closeModal, toast, progressBar, thresholdBadge, stageRow, to
 import { getTerm } from './theme.js';
 import { compressImageToBase64, IMAGE_SIZE_PRESETS } from './imageUtils.js';
 
+// Select mode state for mass move
+let _selectMode = false;
+let _selectedIds = new Set();
+
 // Lazy import to avoid circular dependency
 async function pruneQueues() {
   try {
@@ -138,10 +142,74 @@ export function renderModelPool(containerId = 'modelPool') {
     </div>` + html;
   }
 
+  // Select-mode controls (only when there are models)
+  if (allModels.length) {
+    const selCount = _selectedIds.size;
+    const controlsHtml = `
+      <div class="pool-select-controls">
+        <button class="btn btn-sm${_selectMode ? ' btn-primary' : ''}" id="poolSelectToggle">
+          ${_selectMode ? `☑ Selecting${selCount ? ` (${selCount})` : ''}` : '☐ Select'}
+        </button>
+        ${_selectMode ? `
+          <button class="btn btn-xs" id="poolSelectAll">All</button>
+          <button class="btn btn-xs" id="poolSelectNone">None</button>
+        ` : ''}
+      </div>
+      ${_selectMode && selCount > 0 ? `
+        <div class="mass-move-bar">
+          <span class="mass-move-label">Move ${selCount} to:</span>
+          <select class="form-input mass-move-select" id="massMoveFolder">
+            <option value="">— Unfiled —</option>
+            ${folders.map(f => `<option value="${f.id}">${f.name}</option>`).join('')}
+          </select>
+          <button class="btn btn-sm btn-primary" id="massMoveApply">Move</button>
+        </div>
+      ` : ''}
+    `;
+    html = controlsHtml + html;
+  }
+
   container.innerHTML = html;
 
   container.querySelector('#nudgeArmiesBtn')?.addEventListener('click', () => {
     document.querySelector('.nav-tab[data-tab="collections"]')?.click();
+  });
+
+  // Select mode controls
+  container.querySelector('#poolSelectToggle')?.addEventListener('click', () => {
+    _selectMode = !_selectMode;
+    if (!_selectMode) _selectedIds.clear();
+    renderModelPool(containerId);
+  });
+
+  container.querySelector('#poolSelectAll')?.addEventListener('click', () => {
+    allModels.forEach(m => _selectedIds.add(m.id));
+    renderModelPool(containerId);
+  });
+
+  container.querySelector('#poolSelectNone')?.addEventListener('click', () => {
+    _selectedIds.clear();
+    renderModelPool(containerId);
+  });
+
+  container.querySelector('#massMoveApply')?.addEventListener('click', () => {
+    const folderId = container.querySelector('#massMoveFolder').value || null;
+    const count = _selectedIds.size;
+    _selectedIds.forEach(id => updateModel(id, { folderId }));
+    _selectMode = false;
+    _selectedIds.clear();
+    const dest = folderId ? (appData.folders[folderId]?.name || 'folder') : 'Unfiled';
+    toast(`Moved ${count} model${count !== 1 ? 's' : ''} to ${dest}`, 'success');
+    renderModelPool(containerId);
+  });
+
+  container.querySelectorAll('[data-model-select]').forEach(el => {
+    el.addEventListener('click', () => {
+      const id = el.dataset.modelSelect;
+      if (_selectedIds.has(id)) _selectedIds.delete(id);
+      else _selectedIds.add(id);
+      renderModelPool(containerId);
+    });
   });
 
   // Folder toggle collapse
@@ -205,6 +273,24 @@ export function renderModelPool(containerId = 'modelPool') {
 
 function modelCard(model) {
   const pts = modelPoints(model);
+
+  if (_selectMode) {
+    const checked = _selectedIds.has(model.id);
+    return `
+      <div class="model-card model-card-selectable${checked ? ' model-card-selected' : ''}" data-model-select="${model.id}">
+        <div class="model-select-check">${checked ? '☑' : '☐'}</div>
+        <div class="model-card-header">
+          <div>
+            <div class="model-card-name">${model.name}</div>
+            <div class="model-card-qty">Qty: ${model.quantity}</div>
+          </div>
+        </div>
+        ${progressBar(pts.pct)}
+        <div class="model-card-pts">${pts.pct}% · ${pts.done}/${pts.total} pts</div>
+      </div>
+    `;
+  }
+
   const thresh = modelThreshold(model);
   const badge = thresholdBadge(thresh);
 

--- a/js/owb-import.js
+++ b/js/owb-import.js
@@ -2,7 +2,8 @@
 
 import {
   appData, createCollection, createList, createModel,
-  addModelToList, getModelType, GAME_SYSTEMS
+  addModelToList, getModelType, GAME_SYSTEMS,
+  getAllFolders, createFolder
 } from './data.js';
 import { showModal, closeModal, toast } from './ui.js';
 
@@ -114,7 +115,7 @@ export function parseOwbList(text) {
   return { armyName: armyName || 'Imported Army', gameSystemId, units };
 }
 
-function doImport(text) {
+function doImport(text, folderId = null) {
   const { armyName, gameSystemId, units } = parseOwbList(text);
 
   if (!units.length) return null;
@@ -137,6 +138,7 @@ function doImport(text) {
       gameSystemId,
       modelTypeId: unit.modelTypeId,
       stages,
+      folderId,
     });
     addModelToList(listId, modelId);
   }
@@ -156,12 +158,22 @@ const TYPE_LABELS = {
 
 // Show the import modal. onSuccess(collectionId, listId) is called after a successful import.
 export function showOwbImportModal(onSuccess) {
+  const folders = getAllFolders();
+
   const content = document.createElement('div');
   content.innerHTML = `
     <p style="font-size:0.85em;color:var(--text-muted);margin-bottom:0.75em">
       Paste your army list from the Old World Builder app or website. Units are imported into a new army list; characters, cavalry, and war machines are detected automatically.
     </p>
-    <textarea id="owbPasteArea" class="form-input" rows="14" placeholder="===
+    <div class="form-group" style="margin-bottom:0.75em">
+      <label style="font-size:0.85em;font-weight:600">Import into folder</label>
+      <select id="owbFolderSelect" class="form-input">
+        <option value="">— Unfiled —</option>
+        ${folders.map(f => `<option value="${f.id}">${f.name}</option>`).join('')}
+        <option value="__new__">+ New folder...</option>
+      </select>
+    </div>
+    <textarea id="owbPasteArea" class="form-input" rows="12" placeholder="===
 Clan Eshin [748 pts]
 Warhammer: The Old World, Skaven...
 ===
@@ -178,6 +190,25 @@ Skaven Chieftain [51 pts]
       <button class="btn" id="owbCancelBtn">Cancel</button>
     </div>
   `;
+
+  // Inline folder creation
+  content.querySelector('#owbFolderSelect').addEventListener('change', e => {
+    if (e.target.value === '__new__') {
+      const name = prompt('New folder name:');
+      if (name?.trim()) {
+        const fid = createFolder(name.trim());
+        const opt = document.createElement('option');
+        opt.value = fid;
+        opt.textContent = name.trim();
+        opt.selected = true;
+        const newOpt = e.target.querySelector('[value="__new__"]');
+        e.target.insertBefore(opt, newOpt);
+        e.target.value = fid;
+      } else {
+        e.target.value = '';
+      }
+    }
+  });
 
   const textarea = content.querySelector('#owbPasteArea');
   const preview = content.querySelector('#owbPreview');
@@ -217,7 +248,9 @@ Skaven Chieftain [51 pts]
   content.querySelector('#owbImportBtn').addEventListener('click', () => {
     const text = textarea.value.trim();
     if (!text) { toast('Please paste an army list first', 'error'); return; }
-    const result = doImport(text);
+    const rawFolder = content.querySelector('#owbFolderSelect').value;
+    const folderId = rawFolder && rawFolder !== '__new__' ? rawFolder : null;
+    const result = doImport(text, folderId);
     if (!result) { toast('No units found — check the list format', 'error'); return; }
     closeModal();
     toast(`Imported "${result.armyName}" — ${result.unitCount} unit${result.unitCount !== 1 ? 's' : ''}`, 'success');


### PR DESCRIPTION
- OWB import modal now has a folder dropdown (including inline "new folder"
  creation) so imported units land directly in the chosen folder instead of
  always ending up in Unfiled.
- Model pool gains a Select mode (☐ Select button above the grid): tap cards
  to check/uncheck them, use All/None shortcuts, then choose a target folder
  and hit Move to reassign the whole selection in one go.
- Added supporting CSS for the select controls, mass-move bar, and selected
  card highlight.

https://claude.ai/code/session_01LQBDLsLNYd1J2LVp8Bk18f