### PR TITLE
Replace manual minute entry with start/end time pickers

### DIFF
--- a/index.html
+++ b/index.html
@@ -1215,6 +1215,42 @@
 
     .date-dropdowns .date-yy { flex: 1.3; }
 
+    .time-dropdowns {
+      display: flex;
+      gap: 0.3em;
+      align-items: center;
+      flex: 1;
+    }
+
+    .time-dropdowns .form-input {
+      flex: 1;
+      min-width: 0;
+      padding-left: 0.4em;
+      padding-right: 0.4em;
+    }
+
+    .time-sep {
+      font-weight: bold;
+      color: var(--text-muted);
+      flex-shrink: 0;
+    }
+
+    .time-range-row {
+      display: flex;
+      align-items: center;
+      gap: 0.4em;
+    }
+
+    .time-range-arrow {
+      flex-shrink: 0;
+      color: var(--text-muted);
+      font-size: 0.9em;
+    }
+
+    input[type="time"].form-input {
+      flex: 1;
+    }
+
     /* ================================================================
        DEADLINE CARDS
     ================================================================ */

--- a/js/models.js
+++ b/js/models.js
@@ -7,7 +7,7 @@ import {
   saveModelTypeOverride, resetModelTypeOverride, BUILTIN_MODEL_TYPES,
   createFolder, updateFolder, deleteFolder, getAllFolders
 } from './data.js';
-import { showModal, closeModal, toast, progressBar, thresholdBadge, stageRow, today, createDateInput, getDateValue } from './ui.js';
+import { showModal, closeModal, toast, progressBar, thresholdBadge, stageRow, today, createDateInput, getDateValue, createTimeInput } from './ui.js';
 import { getTerm } from './theme.js';
 import { compressImageToBase64, IMAGE_SIZE_PRESETS } from './imageUtils.js';
 
@@ -720,9 +720,13 @@ export function showLogProgress(modelId) {
         ${createDateInput('lpDate', today())}
       </div>
       <div class="form-group">
-        <label>Time spent (mins)</label>
-        <input id="lpDuration" type="number" class="form-input" min="0" placeholder="e.g. 45">
-        <div class="form-hint log-time-hint">If left blank, logged as historical activity.</div>
+        <label>Session time</label>
+        <div class="time-range-row">
+          ${createTimeInput('lpStartTime')}
+          <span class="time-range-arrow">→</span>
+          ${createTimeInput('lpEndTime')}
+        </div>
+        <div class="form-hint log-time-hint" id="lpDurationHint">If left blank, logged as historical activity.</div>
       </div>
     </div>
     <div class="form-group">
@@ -807,10 +811,46 @@ export function showLogProgress(modelId) {
     }
   });
 
+  // Live duration hint update
+  const calcDurationFromContent = () => {
+    const getT = (id) => {
+      const el = content.querySelector(`#${id}`);
+      if (!el) return '';
+      if (el.tagName === 'INPUT') return el.value;
+      const hh = el.querySelector('.time-hh')?.value;
+      const mm = el.querySelector('.time-mm')?.value;
+      return (hh && mm) ? `${hh}:${mm}` : '';
+    };
+    const start = getT('lpStartTime');
+    const end = getT('lpEndTime');
+    if (!start || !end) return null;
+    const [sh, sm] = start.split(':').map(Number);
+    const [eh, em] = end.split(':').map(Number);
+    let mins = (eh * 60 + em) - (sh * 60 + sm);
+    if (mins < 0) mins += 24 * 60;
+    return mins > 0 ? mins : null;
+  };
+
+  const updateDurationHint = () => {
+    const hint = content.querySelector('#lpDurationHint');
+    if (!hint) return;
+    const mins = calcDurationFromContent();
+    const startEl = content.querySelector('#lpStartTime');
+    const endEl = content.querySelector('#lpEndTime');
+    const hasStart = startEl?.tagName === 'INPUT' ? startEl.value : startEl?.querySelector('.time-hh')?.value;
+    const hasEnd = endEl?.tagName === 'INPUT' ? endEl.value : endEl?.querySelector('.time-hh')?.value;
+    if (hasStart && hasEnd) {
+      hint.textContent = mins ? `= ${mins} mins` : 'End time must be after start time.';
+    } else {
+      hint.textContent = 'If left blank, logged as historical activity.';
+    }
+  };
+
+  content.querySelector('.time-range-row').addEventListener('change', updateDurationHint);
+
   content.querySelector('#lpSave').addEventListener('click', () => {
     const date = getDateValue('lpDate');
-    const rawDuration = content.querySelector('#lpDuration').value;
-    const duration = rawDuration ? (parseInt(rawDuration) || null) : null;
+    const duration = calcDurationFromContent();
     if (!duration && !confirm('No time entered — this will be recorded as historical activity with no session time. Log anyway?')) return;
 
     const modelEntries = [];

--- a/js/ui.js
+++ b/js/ui.js
@@ -220,6 +220,51 @@ export function getDateValue(id) {
   return `${yy}-${mm}-${dd}`;
 }
 
+// --- Smart time input ---
+// On mobile: native <input type="time"> (gives scroll wheels on iOS)
+// On desktop: hour + minute dropdowns in 5-min increments
+
+export function createTimeInput(id, value = '') {
+  const [h = '', m = ''] = value ? value.split(':') : [];
+
+  if (isMobile()) {
+    return `<input type="time" id="${id}" class="form-input" value="${value}">`;
+  }
+
+  const hours = Array.from({length: 24}, (_, i) => i);
+  const minutes = Array.from({length: 12}, (_, i) => i * 5);
+
+  return `
+    <div class="time-dropdowns" id="${id}">
+      <select class="form-input time-hh">
+        <option value="">HH</option>
+        ${hours.map(n => {
+          const val = String(n).padStart(2, '0');
+          return `<option value="${val}" ${h === val ? 'selected' : ''}>${val}</option>`;
+        }).join('')}
+      </select>
+      <span class="time-sep">:</span>
+      <select class="form-input time-mm">
+        <option value="">MM</option>
+        ${minutes.map(n => {
+          const val = String(n).padStart(2, '0');
+          return `<option value="${val}" ${m === val ? 'selected' : ''}>${val}</option>`;
+        }).join('')}
+      </select>
+    </div>
+  `;
+}
+
+export function getTimeValue(id) {
+  const el = document.getElementById(id);
+  if (!el) return '';
+  if (el.tagName === 'INPUT') return el.value;
+  const hh = el.querySelector('.time-hh')?.value;
+  const mm = el.querySelector('.time-mm')?.value;
+  if (!hh || !mm) return '';
+  return `${hh}:${mm}`;
+}
+
 // --- Render a stage progress row ---
 export function stageRow(stage, prog, quantity, skipped) {
   const done = prog?.done || 0;


### PR DESCRIPTION
Users now pick a start time and end time instead of typing minutes
directly. The app calculates the duration automatically and shows a
live hint (e.g. "= 45 mins"). Mobile gets native scroll-wheel time
inputs; desktop gets hour/minute dropdowns in 5-min increments.
Overnight sessions (end < start) are handled via 24h wrap-around.

https://claude.ai/code/session_01M2q7B378VrPjskFiXMSgTg