### PR TITLE
Add virtual unit split for army list display

### DIFF
--- a/index.html
+++ b/index.html
@@ -840,6 +840,72 @@
     .list-model-prog { flex: 1; min-width: 120px; }
     .list-model-actions { display: flex; gap: 0.3em; }
 
+    /* --- Virtual Split --- */
+    .list-model-split-group {
+      margin-bottom: 0.5em;
+      border: 1px solid var(--border);
+      border-radius: var(--radius);
+      overflow: hidden;
+    }
+    .split-group-header {
+      display: flex;
+      align-items: center;
+      gap: 0.5em;
+      padding: 0.45em 0.65em;
+      background: var(--surface2);
+      border-bottom: 1px solid var(--border);
+      flex-wrap: wrap;
+    }
+    .split-group-name { font-weight: 700; font-size: 0.88em; }
+    .split-group-meta { font-size: 0.75em; color: var(--text-muted); }
+    .list-model-split-row {
+      display: flex;
+      align-items: center;
+      gap: 0.75em;
+      padding: 0.55em 0.65em 0.55em 1.2em;
+      background: var(--surface);
+      border-bottom: 1px solid var(--border);
+      cursor: pointer;
+      transition: background 0.15s;
+      flex-wrap: wrap;
+    }
+    .list-model-split-row:last-child { border-bottom: none; }
+    .list-model-split-row:hover { background: var(--surface2); }
+    .list-model-split-row.split-excluded { opacity: 0.5; }
+    .split-badge {
+      display: inline-block;
+      font-size: 0.68em;
+      padding: 0.1em 0.45em;
+      border-radius: 3px;
+      background: var(--bg3);
+      color: var(--text-muted);
+      vertical-align: middle;
+      margin-left: 0.35em;
+    }
+    /* Split modal */
+    .split-modal-desc { font-size: 0.85em; color: var(--text-muted); margin-bottom: 0.8em; }
+    .split-tally {
+      display: flex;
+      gap: 1.2em;
+      font-size: 0.85em;
+      margin-bottom: 0.75em;
+      padding: 0.5em 0.75em;
+      background: var(--surface2);
+      border-radius: var(--radius);
+    }
+    .split-tally-over { color: var(--danger); }
+    .split-rows-container { display: flex; flex-direction: column; gap: 0.4em; margin-bottom: 0.5em; }
+    .split-edit-row {
+      display: flex;
+      align-items: center;
+      gap: 0.4em;
+      flex-wrap: wrap;
+    }
+    .split-name-inp { flex: 1; min-width: 120px; }
+    .split-size-inp { width: 4.5em; flex: 0 0 auto; }
+    .split-inlist-toggle { display: flex; align-items: center; gap: 0.3em; font-size: 0.82em; white-space: nowrap; cursor: pointer; }
+    .split-error { color: var(--danger); font-size: 0.82em; margin-top: 0.4em; }
+
     .pool-filter-row {
       display: flex;
       gap: 0.5em;

--- a/js/collections.js
+++ b/js/collections.js
@@ -3,6 +3,7 @@
 import {
   appData, createCollection, deleteCollection,
   createList, deleteList, addModelToList, removeModelFromList,
+  setModelSplits, removeModelSplits, splitModelPoints, splitModelThreshold,
   listStats, saveData, uid, GAME_SYSTEMS
 } from './data.js';
 import { showModal, closeModal, showConfirm, toast, progressBar, thresholdBadge, createDateInput, getDateValue, formatDate } from './ui.js';
@@ -291,10 +292,24 @@ function selectList(listId) {
       selectList(listId);
     });
   });
+  main.querySelectorAll('[data-model-split]').forEach(el => {
+    el.addEventListener('click', e => {
+      e.stopPropagation();
+      const model = appData.models[el.dataset.modelSplit];
+      if (model) showSplitModal(model, listId);
+    });
+  });
   requestAnimationFrame(() => renderListCompletionPie('listCompletionPieChart', models));
 }
 
 function listModelRow(model, listId) {
+  const list = appData.lists[listId];
+  const splits = (list?.modelSplits || {})[model.id];
+
+  if (splits && splits.length > 0) {
+    return listModelRowSplit(model, listId, splits);
+  }
+
   const pts = calcModelPoints(model);
   const thresh = calcModelThreshold(model);
   return `
@@ -308,11 +323,60 @@ function listModelRow(model, listId) {
         <span class="list-model-thresh">${thresholdBadge(thresh)}</span>
       </div>
       <div class="list-model-actions">
+        <button class="btn btn-sm" data-model-split="${model.id}" title="Split unit">✂️</button>
         <button class="btn btn-sm btn-primary" data-model-log="${model.id}">📝</button>
         <button class="btn btn-sm btn-danger" data-model-remove="${model.id}">✕</button>
       </div>
     </div>
   `;
+}
+
+function listModelRowSplit(model, listId, splits) {
+  let offset = 0;
+  const splitRows = splits.map(split => {
+    const pts = calcSplitPoints(model, split.size, offset);
+    const thresh = calcSplitThreshold(model, split.size, offset);
+    const excluded = !split.inList;
+    offset += split.size;
+    return `
+      <div class="list-model-split-row${excluded ? ' split-excluded' : ''}" data-model-view="${model.id}">
+        <div class="list-model-info">
+          <div class="list-model-name">
+            ${split.name || model.name}
+            ${excluded ? '<span class="split-badge">not in list</span>' : ''}
+          </div>
+          <div class="list-model-qty">×${split.size}</div>
+        </div>
+        <div class="list-model-prog">
+          <div class="prog-bar"><div class="prog-fill" style="width:${pts.pct}%"></div></div>
+          <span class="list-model-thresh">${thresholdBadge(thresh)}</span>
+        </div>
+      </div>
+    `;
+  }).join('');
+
+  return `
+    <div class="list-model-split-group">
+      <div class="split-group-header">
+        <span class="split-group-name">${model.name}</span>
+        <span class="split-group-meta">✂️ split · pool: ×${model.quantity}</span>
+        <div class="list-model-actions" style="margin-left:auto">
+          <button class="btn btn-sm" data-model-split="${model.id}" title="Edit split">✂️ Edit</button>
+          <button class="btn btn-sm btn-primary" data-model-log="${model.id}">📝</button>
+          <button class="btn btn-sm btn-danger" data-model-remove="${model.id}">✕</button>
+        </div>
+      </div>
+      ${splitRows}
+    </div>
+  `;
+}
+
+function calcSplitPoints(model, splitSize, offset) {
+  return splitModelPoints(model, splitSize, offset);
+}
+
+function calcSplitThreshold(model, splitSize, offset) {
+  return splitModelThreshold(model, splitSize, offset);
 }
 
 function calcModelPoints(model) {
@@ -350,6 +414,104 @@ function calcModelThreshold(model) {
     if (allDone) return thresh;
   }
   return hasAnyProgress ? null : 'not_started';
+}
+
+function showSplitModal(model, listId) {
+  const list = appData.lists[listId];
+  if (!list || !model) return;
+
+  const existing = (list.modelSplits || {})[model.id] || [];
+  let splits = existing.length > 0
+    ? existing.map(s => ({ ...s }))
+    : [
+        { id: uid(), name: `${model.name} (1)`, size: Math.ceil(model.quantity / 2), inList: true },
+        { id: uid(), name: `${model.name} (2)`, size: Math.floor(model.quantity / 2), inList: true }
+      ];
+
+  const content = document.createElement('div');
+
+  const render = () => {
+    const usedSize = splits.reduce((sum, s) => sum + (parseInt(s.size) || 0), 0);
+    const remaining = model.quantity - usedSize;
+    const overLimit = remaining < 0;
+
+    content.innerHTML = `
+      <p class="split-modal-desc">
+        Virtually divide this group for display in the army list.
+        Progress is still recorded on the full pool of <strong>${model.quantity}</strong> models — this is just how they appear in the list.
+        The "most finished" models are always allocated to earlier splits.
+      </p>
+      <div class="split-tally">
+        <span>Pool: <strong>${model.quantity}</strong></span>
+        <span>Assigned: <strong>${usedSize}</strong></span>
+        <span class="${overLimit ? 'split-tally-over' : ''}">Unassigned: <strong>${remaining}</strong></span>
+      </div>
+      <div class="split-rows-container">
+        ${splits.map((s, i) => `
+          <div class="split-edit-row" data-idx="${i}">
+            <input class="form-input split-name-inp" type="text" value="${s.name.replace(/"/g, '&quot;')}" placeholder="Unit name" data-field="name" data-idx="${i}">
+            <input class="form-input split-size-inp" type="number" min="1" max="${model.quantity}" value="${s.size}" data-field="size" data-idx="${i}">
+            <label class="split-inlist-toggle" title="Include in army list stats">
+              <input type="checkbox" data-field="inList" data-idx="${i}" ${s.inList ? 'checked' : ''}> In list
+            </label>
+            <button class="btn btn-xs btn-danger" data-remove-idx="${i}">✕</button>
+          </div>
+        `).join('')}
+      </div>
+      <button class="btn btn-sm" id="addSplitPartBtn">+ Add Part</button>
+      ${overLimit ? `<p class="split-error">⚠ Total (${usedSize}) exceeds pool size (${model.quantity}).</p>` : ''}
+      <div class="modal-actions">
+        <button class="btn btn-primary" id="splitSaveBtn" ${overLimit ? 'disabled' : ''}>Save Split</button>
+        ${existing.length > 0 ? `<button class="btn btn-danger" id="splitClearBtn">Remove Split</button>` : ''}
+        <button class="btn" id="splitCancelBtn">Cancel</button>
+      </div>
+    `;
+
+    content.querySelectorAll('[data-field]').forEach(el => {
+      const handler = () => {
+        const idx = parseInt(el.dataset.idx);
+        const field = el.dataset.field;
+        if (field === 'inList') splits[idx].inList = el.checked;
+        else if (field === 'size') splits[idx].size = Math.max(0, parseInt(el.value) || 0);
+        else splits[idx][field] = el.value;
+        render();
+      };
+      el.addEventListener(el.type === 'checkbox' ? 'change' : 'input', handler);
+    });
+
+    content.querySelectorAll('[data-remove-idx]').forEach(el => {
+      el.addEventListener('click', () => {
+        splits.splice(parseInt(el.dataset.removeIdx), 1);
+        render();
+      });
+    });
+
+    content.querySelector('#addSplitPartBtn')?.addEventListener('click', () => {
+      splits.push({ id: uid(), name: `${model.name} (${splits.length + 1})`, size: 0, inList: true });
+      render();
+    });
+
+    content.querySelector('#splitSaveBtn')?.addEventListener('click', () => {
+      const valid = splits.filter(s => s.size > 0);
+      if (!valid.length) { toast('Add at least one split with size > 0', 'error'); return; }
+      setModelSplits(listId, model.id, valid);
+      toast('Split saved', 'success');
+      closeModal();
+      selectList(listId);
+    });
+
+    content.querySelector('#splitClearBtn')?.addEventListener('click', () => {
+      removeModelSplits(listId, model.id);
+      toast('Split removed', 'info');
+      closeModal();
+      selectList(listId);
+    });
+
+    content.querySelector('#splitCancelBtn')?.addEventListener('click', () => closeModal());
+  };
+
+  render();
+  showModal({ title: `✂️ Split: ${model.name}`, content, wide: true });
 }
 
 function showAddModelToList(listId) {
@@ -565,7 +727,21 @@ function shareList(listId) {
     return '█'.repeat(filled) + '░'.repeat(10 - filled) + ` ${pct}%`;
   };
 
+  const modelSplits = list.modelSplits || {};
   const regimentLines = models.map(m => {
+    const splits = modelSplits[m.id];
+    if (splits && splits.length > 0) {
+      let offset = 0;
+      return splits.map(s => {
+        const thresh = calcSplitThreshold(m, s.size, offset);
+        const pts = calcSplitPoints(m, s.size, offset);
+        offset += s.size;
+        const label = threshLabel(thresh);
+        const extra = thresh === null ? ` (${pts.pct}%)` : '';
+        const notInList = !s.inList ? ' [not in list]' : '';
+        return `• ${s.name} ×${s.size} — ${label}${extra}${notInList}`;
+      }).join('\n');
+    }
     const thresh = calcModelThreshold(m);
     const pts = calcModelPoints(m);
     const label = threshLabel(thresh);

--- a/js/data.js
+++ b/js/data.js
@@ -444,9 +444,9 @@ export function updateModel(id, fields) {
 }
 
 export function deleteModel(id) {
-  // Remove from all lists
   Object.values(appData.lists).forEach(list => {
     list.modelIds = list.modelIds.filter(mid => mid !== id);
+    if (list.modelSplits) delete list.modelSplits[id];
   });
   delete appData.models[id];
   saveData();
@@ -514,19 +514,39 @@ export function modelPoints(model) {
 }
 
 export function listStats(list) {
-  const models = (list.modelIds || []).map(id => appData.models[id]).filter(Boolean);
+  const modelSplits = list.modelSplits || {};
   let totalPts = 0, donePts = 0;
   let tableReady = 0, painted = 0, finished = 0, total = 0;
 
-  models.forEach(m => {
-    const pts = modelPoints(m);
-    totalPts += pts.total;
-    donePts += pts.done;
-    total += m.quantity;
-    const thresh = modelThreshold(m);
-    if (thresh === 'table_ready' || thresh === 'painted' || thresh === 'finished') tableReady += m.quantity;
-    if (thresh === 'painted' || thresh === 'finished') painted += m.quantity;
-    if (thresh === 'finished') finished += m.quantity;
+  (list.modelIds || []).forEach(id => {
+    const m = appData.models[id];
+    if (!m) return;
+    const splits = modelSplits[id];
+    if (splits && splits.length > 0) {
+      let offset = 0;
+      splits.forEach(split => {
+        if (split.inList) {
+          const pts = splitModelPoints(m, split.size, offset);
+          const thresh = splitModelThreshold(m, split.size, offset);
+          totalPts += pts.total;
+          donePts += pts.done;
+          total += split.size;
+          if (thresh === 'table_ready' || thresh === 'painted' || thresh === 'finished') tableReady += split.size;
+          if (thresh === 'painted' || thresh === 'finished') painted += split.size;
+          if (thresh === 'finished') finished += split.size;
+        }
+        offset += split.size;
+      });
+    } else {
+      const pts = modelPoints(m);
+      totalPts += pts.total;
+      donePts += pts.done;
+      total += m.quantity;
+      const thresh = modelThreshold(m);
+      if (thresh === 'table_ready' || thresh === 'painted' || thresh === 'finished') tableReady += m.quantity;
+      if (thresh === 'painted' || thresh === 'finished') painted += m.quantity;
+      if (thresh === 'finished') finished += m.quantity;
+    }
   });
 
   return {
@@ -606,8 +626,72 @@ export function removeModelFromList(listId, modelId) {
   const list = appData.lists[listId];
   if (list) {
     list.modelIds = list.modelIds.filter(id => id !== modelId);
+    if (list.modelSplits) delete list.modelSplits[modelId];
     saveData();
   }
+}
+
+export function setModelSplits(listId, modelId, splits) {
+  const list = appData.lists[listId];
+  if (!list) return;
+  if (!list.modelSplits) list.modelSplits = {};
+  list.modelSplits[modelId] = splits;
+  saveData();
+}
+
+export function removeModelSplits(listId, modelId) {
+  const list = appData.lists[listId];
+  if (!list || !list.modelSplits) return;
+  delete list.modelSplits[modelId];
+  saveData();
+}
+
+// Returns points for a virtual slice of a model (most-finished-first ordering).
+// offset = number of models in preceding splits; splitSize = models in this split.
+export function splitModelPoints(model, splitSize, offset) {
+  const stages = model.stages || appData.config.stages;
+  const skipped = model.skippedStages || [];
+  let total = 0, done = 0;
+  stages.forEach(s => {
+    if (skipped.includes(s.id)) return;
+    total += (s.points || 1) * splitSize;
+    const rawDone = model.progress[s.id]?.done || 0;
+    const splitDone = Math.max(0, Math.min(rawDone - offset, splitSize));
+    done += splitDone * (s.points || 1);
+  });
+  return { total, done, pct: total ? Math.round(done / total * 100) : 0 };
+}
+
+// Returns threshold for a virtual slice of a model (most-finished-first ordering).
+export function splitModelThreshold(model, splitSize, offset) {
+  const stages = model.stages || appData.config.stages;
+  const skipped = model.skippedStages || [];
+  const activeStages = stages.filter(s => !skipped.includes(s.id));
+
+  const getSplitDone = s => {
+    const rawDone = model.progress[s.id]?.done || 0;
+    return Math.max(0, Math.min(rawDone - offset, splitSize));
+  };
+
+  const hasAnyProgress = activeStages.some(s => getSplitDone(s) > 0);
+
+  const hasThresholds = stages.some(s => s.threshold);
+  if (!hasThresholds) {
+    const allDone = activeStages.length > 0 && activeStages.every(s => getSplitDone(s) >= splitSize);
+    if (allDone) return 'finished';
+    return hasAnyProgress ? null : 'not_started';
+  }
+
+  for (const thresh of ['finished', 'painted', 'table_ready']) {
+    const threshStageIdx = stages.findIndex(s => s.threshold === thresh);
+    if (threshStageIdx === -1) continue;
+    const allDone = stages.slice(0, threshStageIdx + 1).every(s => {
+      if (skipped.includes(s.id)) return true;
+      return getSplitDone(s) >= splitSize;
+    });
+    if (allDone) return thresh;
+  }
+  return hasAnyProgress ? null : 'not_started';
 }
 
 // --- Session helpers ---


### PR DESCRIPTION
Allows a model group in an army list to be virtually divided into
named sub-units for display purposes. Progress is still tracked on
the full model pool — the split is purely a presentation abstraction.

- Most-finished models are allocated to earlier splits automatically
- Each split can be toggled "in list" (counts toward army stats) or not
- Split groups render with a header, indented sub-rows, and a badge
  on any excluded parts
- Share/export text includes per-split status lines
- Splits are cleaned up when a model is removed from a list or deleted

https://claude.ai/code/session_01K197FFF8QrS95gD4M8jXdH