### PR TITLE
Fix burndown chart x-axis to use time scale with correct proportional spacing

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,6 +10,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@400;600;700&family=MedievalSharp&family=Rajdhani:wght@400;600;700&family=Crimson+Text:ital,wght@0,400;0,600;1,400&display=swap" rel="stylesheet">
   <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/chartjs-adapter-date-fns/dist/chartjs-adapter-date-fns.bundle.min.js"></script>
   <style>
 
     /* ================================================================

--- a/js/charts.js
+++ b/js/charts.js
@@ -274,10 +274,11 @@ export function renderBurndown(canvasId, models, deadline) {
   const dateRange = [...allDates].sort();
 
   let cumSoFar = 0;
-  const actualData = dateRange.map(d => {
+  const actualData = [];
+  dateRange.forEach(d => {
     const entry = cumulativeDates.find(e => e.d === d);
     if (entry) cumSoFar = entry.cum;
-    return d <= todayStr ? cumSoFar : null;
+    if (d <= todayStr) actualData.push({ x: d, y: cumSoFar });
   });
 
   const datasets = [{
@@ -287,14 +288,16 @@ export function renderBurndown(canvasId, models, deadline) {
     backgroundColor: accent() + '26',
     pointRadius: 4,
     tension: 0.3,
-    fill: true,
-    spanGaps: false
+    fill: true
   }];
 
   if (deadline) {
     datasets.push({
       label: 'Ideal',
-      data: dateRange.map((_, i) => Math.round((i / (dateRange.length - 1 || 1)) * totalPts)),
+      data: [
+        { x: dateRange[0], y: 0 },
+        { x: deadline, y: totalPts }
+      ],
       borderColor: '#666',
       borderDash: [6, 4],
       pointRadius: 0,
@@ -305,7 +308,7 @@ export function renderBurndown(canvasId, models, deadline) {
 
   _charts[canvasId] = new Chart(canvas.getContext('2d'), {
     type: 'line',
-    data: { labels: dateRange, datasets },
+    data: { datasets },
     options: {
       responsive: true,
       maintainAspectRatio: false,
@@ -314,7 +317,15 @@ export function renderBurndown(canvasId, models, deadline) {
         tooltip: { mode: 'index', intersect: false }
       },
       scales: {
-        x: { ticks: { color: tickColor(), maxTicksLimit: 8 }, grid: { color: gridColor() } },
+        x: {
+          type: 'time',
+          time: {
+            tooltipFormat: 'yyyy-MM-dd',
+            displayFormats: { day: 'MMM d', week: 'MMM d', month: 'MMM yyyy' }
+          },
+          ticks: { color: tickColor(), maxTicksLimit: 8 },
+          grid: { color: gridColor() }
+        },
         y: {
           min: 0, max: totalPts || 10,
           ticks: { color: tickColor() }, grid: { color: gridColor() },


### PR DESCRIPTION
Previously the x-axis used Chart.js's default category scale, placing each
date at equal intervals regardless of actual time gaps between events.
Switched to a time scale (with chartjs-adapter-date-fns) so spacing reflects
real elapsed time. Also simplified the Ideal line to a two-point straight
line from start to deadline using actual timestamps.

https://claude.ai/code/session_018QokKFpR2b74KL7C8pmkrL