### PR TITLE
Add toggle to weight completion pie charts by hobby points

### DIFF
--- a/index.html
+++ b/index.html
@@ -996,6 +996,9 @@
     .chart-wrap { height: 200px; position: relative; }
     .dash-chart-card { overflow: hidden; }
 
+    .pie-mode-toggle { display: flex; gap: 0.3em; flex-shrink: 0; }
+    .pie-mode-btn.active { background: var(--accent); border-color: var(--accent); color: #fff; }
+
     .dash-army-breakdown { grid-column: 1 / -1; }
     .army-pie-grid { display: flex; flex-wrap: wrap; gap: 1rem; }
     .army-pie-card { flex: 1 1 200px; min-width: 180px; max-width: 280px; }

--- a/js/charts.js
+++ b/js/charts.js
@@ -1,6 +1,6 @@
 // charts.js — all Chart.js rendering
 
-import { appData, GAME_SYSTEMS } from './data.js';
+import { appData, GAME_SYSTEMS, modelPoints, saveData } from './data.js';
 
 // Track chart instances so we can destroy before re-creating
 const _charts = {};
@@ -15,6 +15,41 @@ function accent() {
 
 function gridColor() { return '#2a2a3a'; }
 function tickColor() { return '#888'; }
+
+// ----------------------------------------------------------------
+// Completion pie weighting mode — by model count or by hobby points.
+// A single global, persisted setting shared by all completion pies.
+// ----------------------------------------------------------------
+export function getPieChartMode() {
+  return appData.config.pieChartMode === 'points' ? 'points' : 'count';
+}
+
+export function pieModeToggleHtml() {
+  const mode = getPieChartMode();
+  return `
+    <div class="pie-mode-toggle">
+      <button class="btn btn-xs pie-mode-btn ${mode === 'count' ? 'active' : ''}" data-pie-mode="count">📦 Models</button>
+      <button class="btn btn-xs pie-mode-btn ${mode === 'points' ? 'active' : ''}" data-pie-mode="points">⭐ Points</button>
+    </div>
+  `;
+}
+
+export function wirePieModeToggle(container, onChange) {
+  container.querySelectorAll('[data-pie-mode]').forEach(btn => {
+    btn.addEventListener('click', () => {
+      const newMode = btn.dataset.pieMode;
+      if (getPieChartMode() === newMode) return;
+      appData.config.pieChartMode = newMode;
+      saveData();
+      onChange();
+    });
+  });
+}
+
+// Weight of a model entry for completion pies: head count, or its total hobby points.
+function completionWeight(model, mode) {
+  return mode === 'points' ? modelPoints(model).total : model.quantity;
+}
 
 // ----------------------------------------------------------------
 // PIE: Collection composition by game system
@@ -100,16 +135,18 @@ export function renderCompletionPie(canvasId) {
   if (!canvas) return;
   destroyChart(canvasId);
 
+  const mode = getPieChartMode();
+  const unit = mode === 'points' ? 'pts' : 'models';
   let finished = 0, painted = 0, tableReady = 0, inProgress = 0, notStarted = 0;
 
   Object.values(appData.models).forEach(m => {
     const thresh = calcModelThreshold(m);
-    const qty = m.quantity;
-    if (thresh === 'finished')          finished    += qty;
-    else if (thresh === 'painted')      painted     += qty;
-    else if (thresh === 'table_ready')  tableReady  += qty;
-    else if (thresh === 'not_started')  notStarted  += qty;
-    else                                inProgress  += qty;
+    const weight = completionWeight(m, mode);
+    if (thresh === 'finished')          finished    += weight;
+    else if (thresh === 'painted')      painted     += weight;
+    else if (thresh === 'table_ready')  tableReady  += weight;
+    else if (thresh === 'not_started')  notStarted  += weight;
+    else                                inProgress  += weight;
   });
 
   const total = finished + painted + tableReady + inProgress + notStarted;
@@ -134,7 +171,7 @@ export function renderCompletionPie(canvasId) {
       maintainAspectRatio: false,
       plugins: {
         legend: { position: 'bottom', labels: { color: '#ccc', padding: 10, font: { size: 11 } } },
-        tooltip: { callbacks: { label: ctx => ` ${ctx.label}: ${ctx.parsed} (${Math.round(ctx.parsed/total*100)}%)` } }
+        tooltip: { callbacks: { label: ctx => ` ${ctx.label}: ${ctx.parsed} ${unit} (${Math.round(ctx.parsed/total*100)}%)` } }
       }
     }
   });
@@ -148,15 +185,17 @@ export function renderListCompletionPie(canvasId, models) {
   if (!canvas) return;
   destroyChart(canvasId);
 
+  const mode = getPieChartMode();
+  const unit = mode === 'points' ? 'pts' : 'models';
   let finished = 0, painted = 0, tableReady = 0, inProgress = 0, notStarted = 0;
   models.forEach(m => {
     const thresh = calcModelThreshold(m);
-    const qty = m.quantity;
-    if (thresh === 'finished')          finished   += qty;
-    else if (thresh === 'painted')      painted    += qty;
-    else if (thresh === 'table_ready')  tableReady += qty;
-    else if (thresh === 'not_started')  notStarted += qty;
-    else                                inProgress += qty;
+    const weight = completionWeight(m, mode);
+    if (thresh === 'finished')          finished   += weight;
+    else if (thresh === 'painted')      painted    += weight;
+    else if (thresh === 'table_ready')  tableReady += weight;
+    else if (thresh === 'not_started')  notStarted += weight;
+    else                                inProgress += weight;
   });
 
   const total = finished + painted + tableReady + inProgress + notStarted;
@@ -181,7 +220,7 @@ export function renderListCompletionPie(canvasId, models) {
       maintainAspectRatio: false,
       plugins: {
         legend: { position: 'bottom', labels: { color: '#ccc', padding: 10, font: { size: 11 } } },
-        tooltip: { callbacks: { label: ctx => ` ${ctx.label}: ${ctx.parsed} (${Math.round(ctx.parsed/total*100)}%)` } }
+        tooltip: { callbacks: { label: ctx => ` ${ctx.label}: ${ctx.parsed} ${unit} (${Math.round(ctx.parsed/total*100)}%)` } }
       }
     }
   });

--- a/js/collections.js
+++ b/js/collections.js
@@ -9,7 +9,7 @@ import {
 import { showModal, closeModal, showConfirm, toast, progressBar, thresholdBadge, createDateInput, getDateValue, formatDate } from './ui.js';
 import { applyTheme, resetTheme, setCurrentSystem, resetCurrentSystem, getTerm } from './theme.js';
 import { showLogProgress, showModelDetail } from './models.js';
-import { renderListCompletionPie } from './charts.js';
+import { renderListCompletionPie, pieModeToggleHtml, wirePieModeToggle } from './charts.js';
 import { showImportModal } from './import.js';
 
 let activeCollectionId = null;
@@ -240,7 +240,10 @@ function selectList(listId) {
       </div>
     </div>
     <div class="dash-card list-completion-chart">
-      <h3>Completion Breakdown</h3>
+      <div class="pile-card-header">
+        <h3>Completion Breakdown</h3>
+        ${pieModeToggleHtml()}
+      </div>
       <div class="chart-wrap"><canvas id="listCompletionPieChart"></canvas></div>
     </div>
     <div class="list-models-header">
@@ -299,6 +302,7 @@ function selectList(listId) {
       if (model) showSplitModal(model, listId);
     });
   });
+  wirePieModeToggle(main, () => selectList(listId));
   requestAnimationFrame(() => renderListCompletionPie('listCompletionPieChart', models));
 }
 

--- a/js/dashboard.js
+++ b/js/dashboard.js
@@ -2,7 +2,7 @@
 
 import { appData, globalStats, listStats, saveData, GAME_SYSTEMS, modelThreshold, unstartedCount } from './data.js';
 import { progressBar, toast, daysUntil, formatDate, localDateStr } from './ui.js';
-import { renderCompositionPie, renderCompletionPie, renderBurndown, renderStageBar, renderListCompletionPie } from './charts.js';
+import { renderCompositionPie, renderCompletionPie, renderBurndown, renderStageBar, renderListCompletionPie, pieModeToggleHtml, wirePieModeToggle } from './charts.js';
 import { showModal, closeModal, createDateInput, getDateValue } from './ui.js';
 
 export function renderDashboard() {
@@ -59,7 +59,10 @@ export function renderDashboard() {
 
       <!-- Completion status pie -->
       <div class="dash-card dash-chart-card">
-        <h3>Completion Status</h3>
+        <div class="pile-card-header">
+          <h3>Completion Status</h3>
+          ${pieModeToggleHtml()}
+        </div>
         <div class="chart-wrap"><canvas id="completionPie"></canvas></div>
       </div>
 
@@ -120,6 +123,9 @@ export function renderDashboard() {
       renderDashboard();
     }
   });
+
+  // Pie chart weighting toggle (by model count or hobby points)
+  wirePieModeToggle(container, () => renderDashboard());
 
   // Render pie charts
   requestAnimationFrame(() => {

--- a/js/data.js
+++ b/js/data.js
@@ -340,7 +340,8 @@ export let appData = {
     modelTypes: [],
     modelTypeOverrides: {},
     weeklyGoal: 0,
-    imageSize: 'small'
+    imageSize: 'small',
+    pieChartMode: 'count'
   },
   folders: {}, // id -> { id, name, collapsed }
   queues: {}   // id -> { id, name, entries: [{id, modelId, note}] }
@@ -388,7 +389,8 @@ export function loadData() {
           modelTypes: parsed.config?.modelTypes || [],
           modelTypeOverrides: parsed.config?.modelTypeOverrides || {},
           weeklyGoal: parsed.config?.weeklyGoal || 0,
-          imageSize: parsed.config?.imageSize || 'small'
+          imageSize: parsed.config?.imageSize || 'small',
+          pieChartMode: parsed.config?.pieChartMode || 'count'
         }
       };
     }
@@ -430,7 +432,8 @@ export function replaceData(parsed) {
       modelTypes: parsed.config?.modelTypes || [],
       modelTypeOverrides: parsed.config?.modelTypeOverrides || {},
       weeklyGoal: parsed.config?.weeklyGoal || 0,
-      imageSize: parsed.config?.imageSize || 'small'
+      imageSize: parsed.config?.imageSize || 'small',
+      pieChartMode: parsed.config?.pieChartMode || 'count'
     }
   };
   saveData();


### PR DESCRIPTION
Lets users switch the completion pie charts (dashboard and per-army
list views) between counting by model headcount or by total hobby
points, so a large model isn't visually equal to a single infantry.
The chosen mode is a persisted, global setting shared across all
completion pies.