### PR TITLE
Fix completion breakdown lumping partially-done units into "in progress"

### DIFF
--- a/js/charts.js
+++ b/js/charts.js
@@ -1,6 +1,6 @@
 // charts.js — all Chart.js rendering
 
-import { appData, GAME_SYSTEMS, modelPoints, saveData } from './data.js';
+import { appData, GAME_SYSTEMS, modelPoints, modelThresholdBreakdown, saveData } from './data.js';
 
 // Track chart instances so we can destroy before re-creating
 const _charts = {};
@@ -49,6 +49,13 @@ export function wirePieModeToggle(container, onChange) {
 // Weight of a model entry for these pies: head count, or its total hobby points.
 function modelWeight(model, mode) {
   return mode === 'points' ? modelPoints(model).total : model.quantity;
+}
+
+// Weight of `count` models out of a unit, for these pies: head count, or their share of hobby points.
+function tierWeight(model, count, mode) {
+  if (mode !== 'points') return count;
+  if (!model.quantity) return 0;
+  return count * (modelPoints(model).total / model.quantity);
 }
 
 // ----------------------------------------------------------------
@@ -143,13 +150,12 @@ export function renderCompletionPie(canvasId) {
   let finished = 0, painted = 0, tableReady = 0, inProgress = 0, notStarted = 0;
 
   Object.values(appData.models).forEach(m => {
-    const thresh = calcModelThreshold(m);
-    const weight = modelWeight(m, mode);
-    if (thresh === 'finished')          finished    += weight;
-    else if (thresh === 'painted')      painted     += weight;
-    else if (thresh === 'table_ready')  tableReady  += weight;
-    else if (thresh === 'not_started')  notStarted  += weight;
-    else                                inProgress  += weight;
+    const b = modelThresholdBreakdown(m);
+    finished   += tierWeight(m, b.finished, mode);
+    painted    += tierWeight(m, b.painted, mode);
+    tableReady += tierWeight(m, b.tableReady, mode);
+    inProgress += tierWeight(m, b.inProgress, mode);
+    notStarted += tierWeight(m, b.notStarted, mode);
   });
 
   const total = finished + painted + tableReady + inProgress + notStarted;
@@ -192,13 +198,12 @@ export function renderListCompletionPie(canvasId, models) {
   const unit = mode === 'points' ? 'pts' : 'models';
   let finished = 0, painted = 0, tableReady = 0, inProgress = 0, notStarted = 0;
   models.forEach(m => {
-    const thresh = calcModelThreshold(m);
-    const weight = modelWeight(m, mode);
-    if (thresh === 'finished')          finished   += weight;
-    else if (thresh === 'painted')      painted    += weight;
-    else if (thresh === 'table_ready')  tableReady += weight;
-    else if (thresh === 'not_started')  notStarted += weight;
-    else                                inProgress += weight;
+    const b = modelThresholdBreakdown(m);
+    finished   += tierWeight(m, b.finished, mode);
+    painted    += tierWeight(m, b.painted, mode);
+    tableReady += tierWeight(m, b.tableReady, mode);
+    inProgress += tierWeight(m, b.inProgress, mode);
+    notStarted += tierWeight(m, b.notStarted, mode);
   });
 
   const total = finished + painted + tableReady + inProgress + notStarted;
@@ -376,35 +381,6 @@ export function renderBurndown(canvasId, models, deadline) {
       }
     }
   });
-}
-
-// ----------------------------------------------------------------
-// Inline threshold helper (avoids circular import)
-// ----------------------------------------------------------------
-function calcModelThreshold(model) {
-  const stages = model.stages || appData.config.stages;
-  const skipped = model.skippedStages || [];
-  const activeStages = stages.filter(s => !skipped.includes(s.id));
-  const hasAnyProgress = activeStages.some(s => (model.progress[s.id]?.done || 0) > 0);
-
-  const hasThresholds = stages.some(s => s.threshold);
-  if (!hasThresholds) {
-    const allDone = activeStages.length > 0 &&
-      activeStages.every(s => (model.progress[s.id]?.done || 0) >= model.quantity);
-    if (allDone) return 'finished';
-    return hasAnyProgress ? null : 'not_started';
-  }
-
-  for (const thresh of ['finished', 'painted', 'table_ready']) {
-    const threshStageIdx = stages.findIndex(s => s.threshold === thresh);
-    if (threshStageIdx === -1) continue;
-    const allDone = stages.slice(0, threshStageIdx + 1).every(s => {
-      if (skipped.includes(s.id)) return true;
-      return (model.progress[s.id]?.done || 0) >= model.quantity;
-    });
-    if (allDone) return thresh;
-  }
-  return hasAnyProgress ? null : 'not_started';
 }
 
 export function destroyAllCharts() {

--- a/js/data.js
+++ b/js/data.js
@@ -530,6 +530,63 @@ export function unstartedCount(model) {
   return Math.max(0, model.quantity - maxDone);
 }
 
+// Splits a unit's quantity across threshold tiers instead of bucketing the
+// whole unit by whether EVERY model in it has crossed a given tier — e.g. a
+// unit of 20 with 18 finished and 2 untouched reports {finished:18, ..., notStarted:2}
+// rather than treating the whole 20 as a single not-yet-finished blob.
+function thresholdBreakdown(stages, skipped, qty, doneAt) {
+  const activeStages = stages.filter(s => !skipped.includes(s.id));
+  const reachedThrough = idx => {
+    let min = qty;
+    for (let i = 0; i <= idx; i++) {
+      if (skipped.includes(stages[i].id)) continue;
+      min = Math.min(min, doneAt(stages[i]));
+    }
+    return min;
+  };
+  const maxStarted = activeStages.reduce((max, s) => Math.max(max, doneAt(s)), 0);
+
+  const hasThresholds = stages.some(s => s.threshold);
+  if (!hasThresholds) {
+    const finished = activeStages.length ? reachedThrough(stages.length - 1) : 0;
+    const inProgress = Math.max(0, maxStarted - finished);
+    const notStarted = Math.max(0, qty - finished - inProgress);
+    return { finished, painted: 0, tableReady: 0, inProgress, notStarted };
+  }
+
+  const counts = { finished: 0, painted: 0, tableReady: 0 };
+  let prevReached = 0;
+  ['finished', 'painted', 'table_ready'].forEach(thresh => {
+    const idx = stages.findIndex(s => s.threshold === thresh);
+    if (idx === -1) return;
+    const reached = reachedThrough(idx);
+    counts[thresh === 'table_ready' ? 'tableReady' : thresh] = Math.max(0, reached - prevReached);
+    prevReached = reached;
+  });
+
+  const inProgress = Math.max(0, maxStarted - prevReached);
+  const notStarted = Math.max(0, qty - prevReached - inProgress);
+  return { ...counts, inProgress, notStarted };
+}
+
+// Per-tier counts for a whole model entry (finished/painted/tableReady/inProgress/notStarted sum to model.quantity).
+export function modelThresholdBreakdown(model) {
+  const stages = model.stages || appData.config.stages;
+  const skipped = model.skippedStages || [];
+  return thresholdBreakdown(stages, skipped, model.quantity, s => Math.min(model.progress[s.id]?.done || 0, model.quantity));
+}
+
+// Per-tier counts for a virtual slice of a model (most-finished-first ordering), mirroring splitModelThreshold.
+function splitThresholdBreakdown(model, splitSize, offset) {
+  const stages = model.stages || appData.config.stages;
+  const skipped = model.skippedStages || [];
+  const doneAt = s => {
+    const rawDone = model.progress[s.id]?.done || 0;
+    return Math.max(0, Math.min(rawDone - offset, splitSize));
+  };
+  return thresholdBreakdown(stages, skipped, splitSize, doneAt);
+}
+
 export function modelPoints(model) {
   const stages = model.stages || appData.config.stages;
   const skipped = model.skippedStages || [];
@@ -558,25 +615,25 @@ export function listStats(list) {
       splits.forEach(split => {
         if (split.inList) {
           const pts = splitModelPoints(m, split.size, offset);
-          const thresh = splitModelThreshold(m, split.size, offset);
+          const b = splitThresholdBreakdown(m, split.size, offset);
           totalPts += pts.total;
           donePts += pts.done;
           total += split.size;
-          if (thresh === 'table_ready' || thresh === 'painted' || thresh === 'finished') tableReady += split.size;
-          if (thresh === 'painted' || thresh === 'finished') painted += split.size;
-          if (thresh === 'finished') finished += split.size;
+          tableReady += b.finished + b.painted + b.tableReady;
+          painted += b.finished + b.painted;
+          finished += b.finished;
         }
         offset += split.size;
       });
     } else {
       const pts = modelPoints(m);
+      const b = modelThresholdBreakdown(m);
       totalPts += pts.total;
       donePts += pts.done;
       total += m.quantity;
-      const thresh = modelThreshold(m);
-      if (thresh === 'table_ready' || thresh === 'painted' || thresh === 'finished') tableReady += m.quantity;
-      if (thresh === 'painted' || thresh === 'finished') painted += m.quantity;
-      if (thresh === 'finished') finished += m.quantity;
+      tableReady += b.finished + b.painted + b.tableReady;
+      painted += b.finished + b.painted;
+      finished += b.finished;
     }
   });
 
@@ -594,13 +651,13 @@ export function globalStats() {
 
   models.forEach(m => {
     const pts = modelPoints(m);
+    const b = modelThresholdBreakdown(m);
     totalPts += pts.total;
     donePts += pts.done;
     total += m.quantity;
-    const thresh = modelThreshold(m);
-    if (thresh === 'table_ready' || thresh === 'painted' || thresh === 'finished') tableReady += m.quantity;
-    if (thresh === 'painted' || thresh === 'finished') painted += m.quantity;
-    if (thresh === 'finished') finished += m.quantity;
+    tableReady += b.finished + b.painted + b.tableReady;
+    painted += b.finished + b.painted;
+    finished += b.finished;
   });
 
   return { total, tableReady, painted, finished, totalPts, donePts, pct: totalPts ? Math.round(donePts / totalPts * 100) : 0 };


### PR DESCRIPTION
A unit's quantity was bucketed into a single threshold tier only if every
model in it had crossed that tier, so a unit of 20 with 18 finished and 2
untouched reported 0 finished/painted/table-ready and dumped the whole 20
into "in progress" (or undercounted entirely). Added
modelThresholdBreakdown() to split a unit's quantity granularly across
tiers, and wired it into listStats/globalStats and the completion pie
charts.