### PR TITLE
Replace blank-square not-started icon with a skull

### DIFF
--- a/js/charts.js
+++ b/js/charts.js
@@ -167,7 +167,7 @@ export function renderCompletionPie(canvasId) {
   _charts[canvasId] = new Chart(canvas.getContext('2d'), {
     type: 'doughnut',
     data: {
-      labels: ['🏆 Finished', '🎨 Painted', '⚔️ Table Ready', '🔧 In Progress', '⬜ Not Started'],
+      labels: ['🏆 Finished', '🎨 Painted', '⚔️ Table Ready', '🔧 In Progress', '💀 Not Started'],
       datasets: [{
         data: [finished, painted, tableReady, inProgress, notStarted],
         backgroundColor: ['#c5a028', '#4a9d6f', '#8b7355', '#555570', '#1a1a2e'],
@@ -215,7 +215,7 @@ export function renderListCompletionPie(canvasId, models) {
   _charts[canvasId] = new Chart(canvas.getContext('2d'), {
     type: 'doughnut',
     data: {
-      labels: ['🏆 Finished', '🎨 Painted', '⚔️ Table Ready', '🔧 In Progress', '⬜ Not Started'],
+      labels: ['🏆 Finished', '🎨 Painted', '⚔️ Table Ready', '🔧 In Progress', '💀 Not Started'],
       datasets: [{
         data: [finished, painted, tableReady, inProgress, notStarted],
         backgroundColor: ['#c5a028', '#4a9d6f', '#8b7355', '#555570', '#1a1a2e'],

--- a/js/collections.js
+++ b/js/collections.js
@@ -737,7 +737,7 @@ function shareList(listId) {
     if (thresh === 'finished')     return '🏆 Finished';
     if (thresh === 'painted')      return '🎨 Painted';
     if (thresh === 'table_ready')  return '⚔️ Table Ready';
-    if (thresh === 'not_started')  return '⬜ Not Started';
+    if (thresh === 'not_started')  return '💀 Not Started';
     return '🔧 In Progress';
   };
 

--- a/js/dashboard.js
+++ b/js/dashboard.js
@@ -531,7 +531,7 @@ function pileOfPotentialSection() {
       ${!withUnstarted.length
         ? `<p class="empty-text">Your pile of potential is empty — no models still on the sprue. Impressive!</p>`
         : `
-          <div class="pile-total">⬜ ${totalCount} model${totalCount !== 1 ? 's' : ''} still on the sprue</div>
+          <div class="pile-total">💀 ${totalCount} model${totalCount !== 1 ? 's' : ''} still on the sprue</div>
           <div class="pile-groups">${systemSections}</div>
         `
       }
@@ -572,7 +572,7 @@ function sharePileOfPotential() {
   }).join('\n\n');
 
   const text = [
-    `⬜ My Pile of Potential`,
+    `💀 My Pile of Potential`,
     `${'━'.repeat(24)}`,
     ``,
     `${totalCount} model${totalCount !== 1 ? 's' : ''} still on the sprue...`,

--- a/js/ui.js
+++ b/js/ui.js
@@ -118,7 +118,7 @@ export function thresholdBadge(threshold) {
     painted:      { icon: '🎨', label: 'Painted',       cls: 'badge-painted' },
     finished:     { icon: '🏆', label: 'Finished',      cls: 'badge-finished' },
     null:         { icon: '🔧', label: 'In Progress',   cls: 'badge-wip' },
-    not_started:  { icon: '⬜', label: 'Not Started',   cls: 'badge-not-started' },
+    not_started:  { icon: '💀', label: 'Not Started',   cls: 'badge-not-started' },
   };
   const info = map[threshold] || map[null];
   return `<span class="badge ${info.cls}">${info.icon} ${info.label}</span>`;


### PR DESCRIPTION
The ⬜ badge for unpainted/untouched models felt like a placeholder
rather than a themed status. Swapped it for 💀 across the status
badge, share text, charts, and dashboard pile-of-potential views.