### PR TITLE
Rebalance War Machine stage points to match ~6 infantry worth of work

### DIFF
--- a/index.html
+++ b/index.html
@@ -643,8 +643,8 @@
     .stage-config-row .form-input { width: auto; flex: 1; min-width: 70px; }
     .stage-cfg-pts { max-width: 55px !important; flex: 0 !important; }
     .stage-cfg-milestone { max-width: 130px !important; flex: 0 1 130px !important; font-size: 0.8em !important; padding: 0.3em 0.4em !important; }
-    .stage-cfg-skip { display: flex; align-items: center; gap: 0.3em; font-size: 0.8em; color: var(--text-muted); white-space: nowrap; }
-    .stage-cfg-skip input { width: auto; }
+    .stage-cfg-skip, .stage-cfg-crew { display: flex; align-items: center; gap: 0.3em; font-size: 0.8em; color: var(--text-muted); white-space: nowrap; }
+    .stage-cfg-skip input, .stage-cfg-crew input { width: auto; }
     .stages-section-header { display: flex; align-items: center; justify-content: space-between; margin-bottom: 0.4em; }
     .stages-actions-row { display: flex; gap: 0.5em; margin-top: 0.5em; }
     .pts-detail { font-size: 0.85em; color: var(--text-muted); }

--- a/js/charts.js
+++ b/js/charts.js
@@ -1,6 +1,6 @@
 // charts.js — all Chart.js rendering
 
-import { appData, GAME_SYSTEMS, modelPoints, modelThresholdBreakdown, saveData } from './data.js';
+import { appData, GAME_SYSTEMS, modelPoints, modelThresholdBreakdown, stageCap, saveData } from './data.js';
 
 // Track chart instances so we can destroy before re-creating
 const _charts = {};
@@ -254,9 +254,10 @@ export function renderStageBar(canvasId, models) {
   models.forEach(m => {
     (m.stages || appData.config.stages).forEach(s => {
       if ((m.skippedStages || []).includes(s.id) || !stageMap[s.id]) return;
-      stageMap[s.id].total += (s.points || 1) * m.quantity;
+      const cap = stageCap(s, m);
+      stageMap[s.id].total += (s.points || 1) * cap;
       const prog = m.progress[s.id] || { done: 0 };
-      stageMap[s.id].done += Math.min(prog.done, m.quantity) * (s.points || 1);
+      stageMap[s.id].done += Math.min(prog.done, cap) * (s.points || 1);
     });
   });
 
@@ -303,10 +304,11 @@ export function renderBurndown(canvasId, models, deadline) {
     const skipped = m.skippedStages || [];
     stages.forEach(s => {
       if (skipped.includes(s.id)) return;
-      totalPts += m.quantity * (s.points || 1);
+      const cap = stageCap(s, m);
+      totalPts += cap * (s.points || 1);
       const prog = m.progress[s.id];
       if (prog?.lastDate && prog.done > 0) {
-        const pts = Math.min(prog.done, m.quantity) * (s.points || 1);
+        const pts = Math.min(prog.done, cap) * (s.points || 1);
         byDay[prog.lastDate] = (byDay[prog.lastDate] || 0) + pts;
       }
     });

--- a/js/collections.js
+++ b/js/collections.js
@@ -4,7 +4,7 @@ import {
   appData, createCollection, deleteCollection,
   createList, deleteList, addModelToList, removeModelFromList,
   setModelSplits, removeModelSplits, splitModelPoints, splitModelThreshold,
-  listStats, saveData, uid, GAME_SYSTEMS
+  listStats, saveData, uid, GAME_SYSTEMS, modelPoints, modelThreshold
 } from './data.js';
 import { showModal, closeModal, showConfirm, toast, progressBar, thresholdBadge, createDateInput, getDateValue, formatDate } from './ui.js';
 import { applyTheme, resetTheme, setCurrentSystem, resetCurrentSystem, getTerm } from './theme.js';
@@ -314,8 +314,8 @@ function listModelRow(model, listId) {
     return listModelRowSplit(model, listId, splits);
   }
 
-  const pts = calcModelPoints(model);
-  const thresh = calcModelThreshold(model);
+  const pts = modelPoints(model);
+  const thresh = modelThreshold(model);
   return `
     <div class="list-model-row" data-model-view="${model.id}">
       <div class="list-model-info">
@@ -381,43 +381,6 @@ function calcSplitPoints(model, splitSize, offset) {
 
 function calcSplitThreshold(model, splitSize, offset) {
   return splitModelThreshold(model, splitSize, offset);
-}
-
-function calcModelPoints(model) {
-  const stages = model.stages || appData.config.stages;
-  const skipped = model.skippedStages || [];
-  let total = 0, done = 0;
-  stages.forEach(s => {
-    if (skipped.includes(s.id)) return;
-    total += (s.points || 1) * model.quantity;
-    const prog = model.progress[s.id] || { done: 0 };
-    done += Math.min(prog.done, model.quantity) * (s.points || 1);
-  });
-  return { total, done, pct: total ? Math.round(done / total * 100) : 0 };
-}
-
-function calcModelThreshold(model) {
-  const stages = model.stages || appData.config.stages;
-  const skipped = model.skippedStages || [];
-  const activeStages = stages.filter(s => !skipped.includes(s.id));
-  const hasAnyProgress = activeStages.some(s => (model.progress[s.id]?.done || 0) > 0);
-  const hasThresholds = stages.some(s => s.threshold);
-  if (!hasThresholds) {
-    const allDone = activeStages.length > 0 &&
-      activeStages.every(s => (model.progress[s.id]?.done || 0) >= model.quantity);
-    if (allDone) return 'finished';
-    return hasAnyProgress ? null : 'not_started';
-  }
-  for (const thresh of ['finished', 'painted', 'table_ready']) {
-    const threshStageIdx = stages.findIndex(s => s.threshold === thresh);
-    if (threshStageIdx === -1) continue;
-    const allDone = stages.slice(0, threshStageIdx + 1).every(s => {
-      if (skipped.includes(s.id)) return true;
-      return (model.progress[s.id]?.done || 0) >= model.quantity;
-    });
-    if (allDone) return thresh;
-  }
-  return hasAnyProgress ? null : 'not_started';
 }
 
 function showSplitModal(model, listId) {
@@ -761,8 +724,8 @@ function shareList(listId) {
         return `• ${s.name} ×${s.size} — ${label}${extra}${notInList}`;
       }).join('\n');
     }
-    const thresh = calcModelThreshold(m);
-    const pts = calcModelPoints(m);
+    const thresh = modelThreshold(m);
+    const pts = modelPoints(m);
     const label = threshLabel(thresh);
     const extra = thresh === null ? ` (${pts.pct}%)` : '';
     return `• ${m.name} ×${m.quantity} — ${label}${extra}`;

--- a/js/dashboard.js
+++ b/js/dashboard.js
@@ -618,6 +618,10 @@ function greyBrigadeCount(model) {
   const stages = model.stages || appData.config.stages;
   const skipped = model.skippedStages || [];
 
+  // This heuristic assumes a single ordered stage track; multi-part entries
+  // (hull + crew) don't map onto it, so skip them rather than report bogus counts.
+  if (stages.some(s => s.group === 'crew')) return 0;
+
   const assemblyStage = stages.find(s => s.threshold === 'table_ready');
   if (!assemblyStage) return 0;
 

--- a/js/data.js
+++ b/js/data.js
@@ -128,14 +128,27 @@ export const BUILTIN_MODEL_TYPES = [
     id: 'warmachine',
     name: 'War Machine',
     builtIn: true,
+    // Crew count varies per machine (2-3 typical), so crew stages are tagged
+    // group:'crew' and sized against the model's own crewQuantity instead of
+    // its quantity (which is always 1 machine per entry). Threshold tags sit
+    // on whichever stage — hull or crew — comes last within its phase, so
+    // reaching a milestone always requires both halves to be done.
+    defaultCrewQuantity: 3,
     stages: [
-      { id: 's1', name: 'Assembly',  points: 6, phase: 'assembly', skippable: false, threshold: 'table_ready' },
-      { id: 's2', name: 'Prime',     points: 3, phase: 'painting', skippable: false, threshold: null },
-      { id: 's3', name: 'Basecoat',  points: 6, phase: 'painting', skippable: false, threshold: null },
-      { id: 's4', name: 'Shade',     points: 3, phase: 'painting', skippable: false, threshold: null },
-      { id: 's5', name: 'Layer',     points: 3, phase: 'painting', skippable: true,  threshold: null },
-      { id: 's6', name: 'Highlight', points: 6, phase: 'painting', skippable: true,  threshold: 'painted' },
-      { id: 's7', name: 'Basing',    points: 3, phase: 'basing',   skippable: true,  threshold: 'finished' },
+      { id: 'h1', name: 'Assembly',       points: 6, phase: 'assembly', skippable: false, threshold: null },
+      { id: 'c1', name: 'Crew Assembly',  points: 2, phase: 'assembly', skippable: false, threshold: 'table_ready', group: 'crew' },
+      { id: 'h2', name: 'Prime',          points: 3, phase: 'painting', skippable: false, threshold: null },
+      { id: 'c2', name: 'Crew Prime',     points: 1, phase: 'painting', skippable: false, threshold: null, group: 'crew' },
+      { id: 'h3', name: 'Basecoat',       points: 6, phase: 'painting', skippable: false, threshold: null },
+      { id: 'c3', name: 'Crew Basecoat',  points: 2, phase: 'painting', skippable: false, threshold: null, group: 'crew' },
+      { id: 'h4', name: 'Shade',          points: 3, phase: 'painting', skippable: false, threshold: null },
+      { id: 'c4', name: 'Crew Shade',     points: 1, phase: 'painting', skippable: false, threshold: null, group: 'crew' },
+      { id: 'h5', name: 'Layer',          points: 3, phase: 'painting', skippable: true,  threshold: null },
+      { id: 'c5', name: 'Crew Layer',     points: 1, phase: 'painting', skippable: true,  threshold: null, group: 'crew' },
+      { id: 'h6', name: 'Highlight',      points: 6, phase: 'painting', skippable: true,  threshold: null },
+      { id: 'c6', name: 'Crew Highlight', points: 2, phase: 'painting', skippable: true,  threshold: 'painted', group: 'crew' },
+      { id: 'h7', name: 'Basing',         points: 3, phase: 'basing',   skippable: true,  threshold: null },
+      { id: 'c7', name: 'Crew Basing',    points: 1, phase: 'basing',   skippable: true,  threshold: 'finished', group: 'crew' },
     ]
   },
   {
@@ -452,7 +465,7 @@ export function getModel(id) { return appData.models[id]; }
 
 export function getAllModels() { return Object.values(appData.models); }
 
-export function createModel({ name, quantity = 1, notes = '', gameSystemId = null, stages = null, skippedStages = [], folderId = null, image = null, modelTypeId = null }) {
+export function createModel({ name, quantity = 1, notes = '', gameSystemId = null, stages = null, skippedStages = [], folderId = null, image = null, modelTypeId = null, crewQuantity = null }) {
   const id = uid();
   const modelStages = stages || appData.config.stages.map(s => ({ ...s }));
   appData.models[id] = {
@@ -460,12 +473,22 @@ export function createModel({ name, quantity = 1, notes = '', gameSystemId = nul
     stages: modelStages,
     skippedStages,
     modelTypeId,
+    crewQuantity,
     dateAdded: new Date().toISOString().slice(0, 10),
     progress: {},
     sessions: []
   };
   saveData();
   return id;
+}
+
+// The denominator a stage's progress is tracked against: a model's own
+// quantity normally, or its crewQuantity for stages tagged group:'crew'
+// (used by multi-part entries like War Machines, where crew count varies
+// independently of the 1 machine the entry otherwise represents).
+export function stageCap(stage, model) {
+  if (stage && stage.group === 'crew') return model.crewQuantity || 0;
+  return model.quantity;
 }
 
 export function updateModel(id, fields) {
@@ -486,8 +509,10 @@ export function deleteModel(id) {
 export function logProgress(modelId, stageId, done, date) {
   const model = appData.models[modelId];
   if (!model) return;
+  const stage = (model.stages || appData.config.stages).find(s => s.id === stageId);
+  const cap = stageCap(stage, model);
   if (!model.progress[stageId]) model.progress[stageId] = { done: 0, lastDate: null };
-  model.progress[stageId].done = Math.max(0, Math.min(done, model.quantity));
+  model.progress[stageId].done = Math.max(0, Math.min(done, cap));
   model.progress[stageId].lastDate = date;
   saveData();
 }
@@ -504,7 +529,7 @@ export function modelThreshold(model) {
   const hasThresholds = stages.some(s => s.threshold);
   if (!hasThresholds) {
     const allDone = activeStages.length > 0 &&
-      activeStages.every(s => (model.progress[s.id]?.done || 0) >= model.quantity);
+      activeStages.every(s => (model.progress[s.id]?.done || 0) >= stageCap(s, model));
     if (allDone) return 'finished';
     return hasAnyProgress ? null : 'not_started';
   }
@@ -515,7 +540,7 @@ export function modelThreshold(model) {
     if (threshStageIdx === -1) continue;
     const allDone = stages.slice(0, threshStageIdx + 1).every(s => {
       if (skipped.includes(s.id)) return true;
-      return (model.progress[s.id]?.done || 0) >= model.quantity;
+      return (model.progress[s.id]?.done || 0) >= stageCap(s, model);
     });
     if (allDone) return thresh;
   }
@@ -526,6 +551,12 @@ export function unstartedCount(model) {
   const stages = model.stages || appData.config.stages;
   const skipped = model.skippedStages || [];
   const activeStages = stages.filter(s => !skipped.includes(s.id));
+  if (stages.some(s => s.group === 'crew')) {
+    // Multi-part entries (e.g. War Machine + crew) are always exactly 1 unit —
+    // "on the sprue" just means nothing on either the hull or crew side has begun.
+    const hasAnyProgress = activeStages.some(s => (model.progress[s.id]?.done || 0) > 0);
+    return hasAnyProgress ? 0 : model.quantity;
+  }
   const maxDone = activeStages.reduce((max, s) => Math.max(max, model.progress[s.id]?.done || 0), 0);
   return Math.max(0, model.quantity - maxDone);
 }
@@ -573,6 +604,18 @@ function thresholdBreakdown(stages, skipped, qty, doneAt) {
 export function modelThresholdBreakdown(model) {
   const stages = model.stages || appData.config.stages;
   const skipped = model.skippedStages || [];
+  if (stages.some(s => s.group === 'crew')) {
+    // Mixed-denominator entries (hull qty vs crew qty) aren't a batch that can be
+    // bucketed fractionally — they're always 1 unit, gated all-or-nothing by modelThreshold.
+    const thresh = modelThreshold(model);
+    const counts = { finished: 0, painted: 0, tableReady: 0, inProgress: 0, notStarted: 0 };
+    if (thresh === 'finished') counts.finished = model.quantity;
+    else if (thresh === 'painted') counts.painted = model.quantity;
+    else if (thresh === 'table_ready') counts.tableReady = model.quantity;
+    else if (thresh === null) counts.inProgress = model.quantity;
+    else counts.notStarted = model.quantity;
+    return counts;
+  }
   return thresholdBreakdown(stages, skipped, model.quantity, s => Math.min(model.progress[s.id]?.done || 0, model.quantity));
 }
 
@@ -593,10 +636,11 @@ export function modelPoints(model) {
   let total = 0, done = 0;
   stages.forEach(s => {
     if (skipped.includes(s.id)) return;
-    const pts = (s.points || 1) * model.quantity;
+    const cap = stageCap(s, model);
+    const pts = (s.points || 1) * cap;
     const prog = model.progress[s.id] || { done: 0 };
     total += pts;
-    done += Math.min(prog.done, model.quantity) * (s.points || 1);
+    done += Math.min(prog.done, cap) * (s.points || 1);
   });
   return { total, done, pct: total ? Math.round(done / total * 100) : 0 };
 }

--- a/js/data.js
+++ b/js/data.js
@@ -129,13 +129,13 @@ export const BUILTIN_MODEL_TYPES = [
     name: 'War Machine',
     builtIn: true,
     stages: [
-      { id: 's1', name: 'Assembly',  points: 12, phase: 'assembly', skippable: false, threshold: 'table_ready' },
-      { id: 's2', name: 'Prime',     points: 6,  phase: 'painting', skippable: false, threshold: null },
-      { id: 's3', name: 'Basecoat',  points: 12, phase: 'painting', skippable: false, threshold: null },
-      { id: 's4', name: 'Shade',     points: 6,  phase: 'painting', skippable: false, threshold: null },
-      { id: 's5', name: 'Layer',     points: 6,  phase: 'painting', skippable: true,  threshold: null },
-      { id: 's6', name: 'Highlight', points: 12, phase: 'painting', skippable: true,  threshold: 'painted' },
-      { id: 's7', name: 'Basing',    points: 6,  phase: 'basing',   skippable: true,  threshold: 'finished' },
+      { id: 's1', name: 'Assembly',  points: 6, phase: 'assembly', skippable: false, threshold: 'table_ready' },
+      { id: 's2', name: 'Prime',     points: 3, phase: 'painting', skippable: false, threshold: null },
+      { id: 's3', name: 'Basecoat',  points: 6, phase: 'painting', skippable: false, threshold: null },
+      { id: 's4', name: 'Shade',     points: 3, phase: 'painting', skippable: false, threshold: null },
+      { id: 's5', name: 'Layer',     points: 3, phase: 'painting', skippable: true,  threshold: null },
+      { id: 's6', name: 'Highlight', points: 6, phase: 'painting', skippable: true,  threshold: 'painted' },
+      { id: 's7', name: 'Basing',    points: 3, phase: 'basing',   skippable: true,  threshold: 'finished' },
     ]
   },
   {

--- a/js/data.js
+++ b/js/data.js
@@ -129,13 +129,13 @@ export const BUILTIN_MODEL_TYPES = [
     name: 'War Machine',
     builtIn: true,
     stages: [
-      { id: 's1', name: 'Assembly',  points: 4, phase: 'assembly', skippable: false, threshold: 'table_ready' },
-      { id: 's2', name: 'Prime',     points: 1, phase: 'painting', skippable: false, threshold: null },
-      { id: 's3', name: 'Basecoat',  points: 3, phase: 'painting', skippable: false, threshold: null },
-      { id: 's4', name: 'Shade',     points: 1, phase: 'painting', skippable: false, threshold: null },
-      { id: 's5', name: 'Layer',     points: 1, phase: 'painting', skippable: true,  threshold: null },
-      { id: 's6', name: 'Highlight', points: 2, phase: 'painting', skippable: true,  threshold: 'painted' },
-      { id: 's7', name: 'Basing',    points: 2, phase: 'basing',   skippable: true,  threshold: 'finished' },
+      { id: 's1', name: 'Assembly',  points: 12, phase: 'assembly', skippable: false, threshold: 'table_ready' },
+      { id: 's2', name: 'Prime',     points: 6,  phase: 'painting', skippable: false, threshold: null },
+      { id: 's3', name: 'Basecoat',  points: 12, phase: 'painting', skippable: false, threshold: null },
+      { id: 's4', name: 'Shade',     points: 6,  phase: 'painting', skippable: false, threshold: null },
+      { id: 's5', name: 'Layer',     points: 6,  phase: 'painting', skippable: true,  threshold: null },
+      { id: 's6', name: 'Highlight', points: 12, phase: 'painting', skippable: true,  threshold: 'painted' },
+      { id: 's7', name: 'Basing',    points: 6,  phase: 'basing',   skippable: true,  threshold: 'finished' },
     ]
   },
   {

--- a/js/models.js
+++ b/js/models.js
@@ -2,7 +2,7 @@
 
 import {
   appData, createModel, updateModel, deleteModel,
-  logProgress, logSession, modelPoints, modelThreshold, uid, saveData,
+  logProgress, logSession, modelPoints, modelThreshold, stageCap, uid, saveData,
   getAllModelTypes, saveCustomModelType, deleteCustomModelType,
   saveModelTypeOverride, resetModelTypeOverride, BUILTIN_MODEL_TYPES,
   createFolder, updateFolder, deleteFolder, getAllFolders
@@ -271,6 +271,11 @@ export function renderModelPool(containerId = 'modelPool') {
   });
 }
 
+function qtyLabel(model) {
+  const hasCrew = (model.stages || appData.config.stages).some(s => s.group === 'crew');
+  return hasCrew ? `Qty: ${model.quantity} · Crew: ${model.crewQuantity || 0}` : `Qty: ${model.quantity}`;
+}
+
 function modelCard(model) {
   const pts = modelPoints(model);
 
@@ -282,7 +287,7 @@ function modelCard(model) {
         <div class="model-card-header">
           <div>
             <div class="model-card-name">${model.name}</div>
-            <div class="model-card-qty">Qty: ${model.quantity}</div>
+            <div class="model-card-qty">${qtyLabel(model)}</div>
           </div>
         </div>
         ${progressBar(pts.pct)}
@@ -300,7 +305,7 @@ function modelCard(model) {
       <div class="model-card-header">
         <div>
           <div class="model-card-name">${model.name}</div>
-          <div class="model-card-qty">Qty: ${model.quantity}</div>
+          <div class="model-card-qty">${qtyLabel(model)}</div>
         </div>
         ${badge}
       </div>
@@ -327,7 +332,7 @@ export function showModelDetail(modelId) {
   const skipped = model.skippedStages || [];
 
   const stagesHtml = stages.map(s =>
-    stageRow(s, model.progress[s.id], model.quantity, skipped)
+    stageRow(s, model.progress[s.id], stageCap(s, model), skipped)
   ).join('');
 
   const content = document.createElement('div');
@@ -335,7 +340,7 @@ export function showModelDetail(modelId) {
     ${model.image ? `<img class="detail-image" src="${model.image}" alt="${model.name}">` : ''}
     <div class="detail-header">
       <div>
-        <div class="detail-qty">Quantity: <b>${model.quantity}</b></div>
+        <div class="detail-qty">${qtyLabel(model)}</div>
         ${model.notes ? `<div class="detail-notes">${model.notes}</div>` : ''}
       </div>
       ${thresholdBadge(thresh)}
@@ -412,6 +417,8 @@ export function showModelForm(editId = null, defaultFolderId = null) {
   const stagesLabelHtml = hasType
     ? `Using <b>${selectedType.name}</b> stages`
     : `Hobby Stages <span class="form-hint">(edit points or toggle skipped)</span>`;
+  const hasCrew = stages.some(s => s.group === 'crew');
+  const initialCrewQty = model?.crewQuantity ?? selectedType?.defaultCrewQuantity ?? 3;
 
   const content = document.createElement('div');
   content.innerHTML = `
@@ -422,7 +429,8 @@ export function showModelForm(editId = null, defaultFolderId = null) {
     <div class="form-row-two">
       <div class="form-group">
         <label>Quantity</label>
-        <input id="mfQty" type="number" class="form-input" min="1" value="${model?.quantity || 1}">
+        <input id="mfQty" type="number" class="form-input" min="1" value="${hasCrew ? 1 : (model?.quantity || 1)}" ${hasCrew ? 'disabled' : ''}>
+        <span class="form-hint" id="mfQtyHint" style="${hasCrew ? '' : 'display:none'}">Multi-part entries (crew) are always 1 per entry</span>
       </div>
       <div class="form-group">
         <label>Folder</label>
@@ -432,6 +440,11 @@ export function showModelForm(editId = null, defaultFolderId = null) {
           <option value="__new__">+ New folder...</option>
         </select>
       </div>
+    </div>
+    <div class="form-group" id="mfCrewQtyGroup" style="${hasCrew ? '' : 'display:none'}">
+      <label>Crew Quantity</label>
+      <input id="mfCrewQty" type="number" class="form-input" min="0" value="${initialCrewQty}">
+      <span class="form-hint">How many crew this particular model has</span>
     </div>
     <div class="form-group">
       <label>Notes (optional)</label>
@@ -545,6 +558,29 @@ export function showModelForm(editId = null, defaultFolderId = null) {
     stagesToggle.textContent = isHidden ? '▲ Collapse' : '▶ Customize';
   });
 
+  function refreshCrewQtyUI(resetTo) {
+    const hasCrewNow = collectStages(content).some(s => s.group === 'crew');
+    const qtyInput = content.querySelector('#mfQty');
+    const qtyHint = content.querySelector('#mfQtyHint');
+    const crewGroup = content.querySelector('#mfCrewQtyGroup');
+    const crewInput = content.querySelector('#mfCrewQty');
+    if (hasCrewNow) {
+      qtyInput.value = 1;
+      qtyInput.disabled = true;
+      qtyHint.style.display = '';
+      crewGroup.style.display = '';
+      if (resetTo != null) crewInput.value = resetTo;
+    } else {
+      qtyInput.disabled = false;
+      qtyHint.style.display = 'none';
+      crewGroup.style.display = 'none';
+    }
+  }
+
+  content.querySelector('#mfStages').addEventListener('change', e => {
+    if (e.target.classList.contains('stage-cfg-crew-cb')) refreshCrewQtyUI();
+  });
+
   typeSelect.addEventListener('change', () => {
     const typeId = typeSelect.value;
     if (typeId) {
@@ -555,10 +591,12 @@ export function showModelForm(editId = null, defaultFolderId = null) {
       stagesBody.style.display = 'none';
       stagesToggle.textContent = '▶ Customize';
       stagesToggle.style.display = '';
+      refreshCrewQtyUI(preset.defaultCrewQuantity ?? 3);
     } else {
       stagesLabel.innerHTML = `Hobby Stages <span class="form-hint">(edit points or toggle skipped)</span>`;
       stagesBody.style.display = '';
       stagesToggle.style.display = 'none';
+      refreshCrewQtyUI();
     }
     updateTypeManage(content, typeId, allTypes);
   });
@@ -582,7 +620,7 @@ export function showModelForm(editId = null, defaultFolderId = null) {
   });
 
   content.querySelector('#mfAddStage').addEventListener('click', () => {
-    const s = { id: uid(), name: '', points: 1, skippable: true };
+    const s = { id: uid(), name: '', points: 1, phase: 'painting', skippable: true };
     const row = document.createElement('div');
     row.innerHTML = stageConfigRow(s, []);
     content.querySelector('#mfStages').appendChild(row.firstElementChild);
@@ -591,12 +629,12 @@ export function showModelForm(editId = null, defaultFolderId = null) {
   content.querySelector('#mfStages').addEventListener('click', e => {
     if (e.target.classList.contains('stage-cfg-del')) {
       e.target.closest('.stage-config-row').remove();
+      refreshCrewQtyUI();
     }
   });
 
   content.querySelector('#mfSave').addEventListener('click', () => {
     const name = content.querySelector('#mfName').value.trim();
-    const quantity = parseInt(content.querySelector('#mfQty').value) || 1;
     const notes = content.querySelector('#mfNotes').value.trim();
     const modelTypeId = typeSelect.value || null;
     let folderId = content.querySelector('#mfFolder').value || null;
@@ -605,12 +643,15 @@ export function showModelForm(editId = null, defaultFolderId = null) {
     if (!name) { toast('Please enter a name', 'error'); return; }
 
     const { stages: newStages, skipped: newSkipped } = collectStagesAndSkipped(content);
+    const hasCrewNow = newStages.some(s => s.group === 'crew');
+    const quantity = hasCrewNow ? 1 : (parseInt(content.querySelector('#mfQty').value) || 1);
+    const crewQuantity = hasCrewNow ? (parseInt(content.querySelector('#mfCrewQty').value) || 0) : null;
 
     if (editId) {
-      updateModel(editId, { name, quantity, notes, modelTypeId, folderId, stages: newStages, skippedStages: newSkipped, image: currentImage });
+      updateModel(editId, { name, quantity, notes, modelTypeId, folderId, stages: newStages, skippedStages: newSkipped, image: currentImage, crewQuantity });
       toast('Updated!', 'success');
     } else {
-      createModel({ name, quantity, notes, modelTypeId, folderId, stages: newStages, skippedStages: newSkipped, image: currentImage });
+      createModel({ name, quantity, notes, modelTypeId, folderId, stages: newStages, skippedStages: newSkipped, image: currentImage, crewQuantity });
       toast(`${getTerm('model')} added!`, 'success');
     }
 
@@ -629,12 +670,15 @@ function stageConfigRow(s, skipped) {
     { value: 'finished',    label: '🏆 Finished' },
   ];
   return `
-    <div class="stage-config-row" data-sid="${s.id}">
+    <div class="stage-config-row" data-sid="${s.id}" data-phase="${s.phase || 'painting'}" data-skippable="${s.skippable ?? true}">
       <input type="text" class="form-input stage-cfg-name" value="${s.name}" placeholder="Stage name">
       <input type="number" class="form-input stage-cfg-pts" value="${s.points || 1}" min="0" max="20" title="Hobby points for this stage (used for weekly goal tracking)">
       <select class="form-input stage-cfg-milestone" title="Milestone this stage completes">
         ${milestoneOptions.map(o => `<option value="${o.value}" ${(s.threshold || '') === o.value ? 'selected' : ''}>${o.label}</option>`).join('')}
       </select>
+      <label class="stage-cfg-crew" title="Track this stage against crew count instead of quantity">
+        <input type="checkbox" class="stage-cfg-crew-cb" ${s.group === 'crew' ? 'checked' : ''}> Crew
+      </label>
       <label class="stage-cfg-skip" title="Skip this stage for this regiment">
         <input type="checkbox" class="stage-cfg-skipped" ${skipped.includes(s.id) ? 'checked' : ''}> Skip
       </label>
@@ -649,7 +693,13 @@ function collectStages(content) {
     const name = row.querySelector('.stage-cfg-name').value.trim();
     const pts = parseInt(row.querySelector('.stage-cfg-pts').value) || 1;
     const threshold = row.querySelector('.stage-cfg-milestone').value || null;
-    if (name) stages.push({ id: row.dataset.sid, name, points: pts, threshold });
+    const isCrew = row.querySelector('.stage-cfg-crew-cb')?.checked;
+    if (name) stages.push({
+      id: row.dataset.sid, name, points: pts, threshold,
+      phase: row.dataset.phase || 'painting',
+      skippable: row.dataset.skippable !== 'false',
+      ...(isCrew ? { group: 'crew' } : {})
+    });
   });
   return stages;
 }
@@ -662,8 +712,14 @@ function collectStagesAndSkipped(content) {
     const pts = parseInt(row.querySelector('.stage-cfg-pts').value) || 1;
     const threshold = row.querySelector('.stage-cfg-milestone').value || null;
     const skip = row.querySelector('.stage-cfg-skipped').checked;
+    const isCrew = row.querySelector('.stage-cfg-crew-cb')?.checked;
     if (name) {
-      stages.push({ id: row.dataset.sid, name, points: pts, threshold });
+      stages.push({
+        id: row.dataset.sid, name, points: pts, threshold,
+        phase: row.dataset.phase || 'painting',
+        skippable: row.dataset.skippable !== 'false',
+        ...(isCrew ? { group: 'crew' } : {})
+      });
       if (skip) skipped.push(row.dataset.sid);
     }
   });
@@ -708,12 +764,16 @@ export function showLogProgress(modelId) {
   if (!model) return;
 
   const stages = (model.stages || appData.config.stages).filter(s => !(model.skippedStages || []).includes(s.id));
+  const hasCrew = (model.stages || appData.config.stages).some(s => s.group === 'crew');
 
   const content = document.createElement('div');
-  const isSingle = model.quantity === 1;
+
+  const qtyLabelText = hasCrew
+    ? `(1 model, ${model.crewQuantity || 0} crew)`
+    : `(${model.quantity} model${model.quantity > 1 ? 's' : ''})`;
 
   content.innerHTML = `
-    <div class="log-model-name">${model.name} <span class="log-qty">(${model.quantity} model${model.quantity > 1 ? 's' : ''})</span></div>
+    <div class="log-model-name">${model.name} <span class="log-qty">${qtyLabelText}</span></div>
     <div class="form-row-two">
       <div class="form-group">
         <label>Date</label>
@@ -737,25 +797,27 @@ export function showLogProgress(modelId) {
       </div>
       <div class="log-stages" id="lpStages">
         ${stages.map(s => {
+          const cap = stageCap(s, model);
           const prog = model.progress[s.id] || { done: 0 };
-          const isDone = prog.done >= model.quantity;
-          if (isSingle) {
+          const isDone = cap > 0 && prog.done >= cap;
+          const crewTag = s.group === 'crew' ? ' <span class="stage-opt">crew</span>' : '';
+          if (cap <= 1) {
             return `
               <label class="log-stage-check ${isDone ? 'is-done' : ''}">
                 <input type="checkbox" class="stage-checkbox" id="lp_${s.id}" data-sid="${s.id}" ${isDone ? 'checked' : ''}>
-                <span class="log-stage-name">${s.name}</span>
+                <span class="log-stage-name">${s.name}${crewTag}</span>
               </label>
             `;
           }
           return `
             <div class="log-stage-row${isDone ? ' stage-done' : ''}">
-              <div class="log-stage-name">${s.name}${isDone ? ' <span class="stage-done-badge">✓</span>' : ''}</div>
+              <div class="log-stage-name">${s.name}${crewTag}${isDone ? ' <span class="stage-done-badge">✓</span>' : ''}</div>
               <div class="log-stage-input">
                 <button class="btn btn-sm qty-dec" data-sid="${s.id}">−</button>
                 <input type="number" class="form-input qty-input" id="lp_${s.id}"
-                  data-sid="${s.id}" min="0" max="${model.quantity}" value="${prog.done}">
-                <button class="btn btn-sm qty-inc" data-sid="${s.id}" data-max="${model.quantity}">+</button>
-                <span class="qty-max">/ ${model.quantity}</span>
+                  data-sid="${s.id}" min="0" max="${cap}" value="${prog.done}">
+                <button class="btn btn-sm qty-inc" data-sid="${s.id}" data-max="${cap}">+</button>
+                <span class="qty-max">/ ${cap}</span>
               </div>
             </div>
           `;
@@ -773,7 +835,7 @@ export function showLogProgress(modelId) {
     const sid = e.target.dataset.sid;
     if (!sid) return;
     const input = content.querySelector(`#lp_${sid}`);
-    const max = parseInt(e.target.dataset.max || model.quantity);
+    const max = parseInt(e.target.dataset.max || 0);
     if (e.target.classList.contains('qty-inc')) {
       input.value = Math.min(max, parseInt(input.value || 0) + 1);
     }
@@ -784,31 +846,25 @@ export function showLogProgress(modelId) {
 
   // All Done — set every stage to full quantity / tick all checkboxes
   content.querySelector('#lpAllDone').addEventListener('click', () => {
-    if (isSingle) {
-      content.querySelectorAll('.stage-checkbox').forEach(cb => {
-        cb.checked = true;
-        cb.closest('.log-stage-check').classList.add('is-done');
-      });
-    } else {
-      content.querySelectorAll('.qty-input').forEach(input => {
-        input.value = model.quantity;
-      });
-    }
+    content.querySelectorAll('.stage-checkbox').forEach(cb => {
+      cb.checked = true;
+      cb.closest('.log-stage-check').classList.add('is-done');
+    });
+    content.querySelectorAll('.qty-input').forEach(input => {
+      input.value = input.max;
+    });
   });
 
   // Reset All — zero everything out
   content.querySelector('#lpReset').addEventListener('click', () => {
     if (!confirm('Reset all stage progress to zero? This cannot be undone.')) return;
-    if (isSingle) {
-      content.querySelectorAll('.stage-checkbox').forEach(cb => {
-        cb.checked = false;
-        cb.closest('.log-stage-check').classList.remove('is-done');
-      });
-    } else {
-      content.querySelectorAll('.qty-input').forEach(input => {
-        input.value = 0;
-      });
-    }
+    content.querySelectorAll('.stage-checkbox').forEach(cb => {
+      cb.checked = false;
+      cb.closest('.log-stage-check').classList.remove('is-done');
+    });
+    content.querySelectorAll('.qty-input').forEach(input => {
+      input.value = 0;
+    });
   });
 
   // Live duration hint update
@@ -855,13 +911,14 @@ export function showLogProgress(modelId) {
 
     const modelEntries = [];
     stages.forEach(s => {
+      const cap = stageCap(s, model);
       let done;
-      if (isSingle) {
+      if (cap <= 1) {
         const cb = content.querySelector(`#lp_${s.id}`);
         done = cb?.checked ? 1 : 0;
       } else {
         const input = content.querySelector(`#lp_${s.id}`);
-        done = Math.min(parseInt(input?.value) || 0, model.quantity);
+        done = Math.min(parseInt(input?.value) || 0, cap);
       }
       const prev = model.progress[s.id]?.done || 0;
       if (done !== prev) modelEntries.push({ modelId, stageId: s.id, qty: done - prev });
@@ -900,6 +957,9 @@ function stageTemplateRow(s) {
       <select class="form-input stage-cfg-milestone" title="Milestone this stage completes">
         ${milestoneOptions.map(o => `<option value="${o.value}" ${(s.threshold || '') === o.value ? 'selected' : ''}>${o.label}</option>`).join('')}
       </select>
+      <label class="stage-cfg-crew" title="Track this stage against a per-entry crew count instead of quantity">
+        <input type="checkbox" class="stage-cfg-crew-cb" ${s.group === 'crew' ? 'checked' : ''}> Crew
+      </label>
       <button class="btn btn-xs btn-danger stage-cfg-del" title="Remove stage">✕</button>
     </div>
   `;
@@ -911,13 +971,15 @@ function collectTemplateStages(container) {
     const name = row.querySelector('.stage-cfg-name').value.trim();
     const pts = parseInt(row.querySelector('.stage-cfg-pts').value) || 1;
     const threshold = row.querySelector('.stage-cfg-milestone').value || null;
+    const isCrew = row.querySelector('.stage-cfg-crew-cb')?.checked;
     if (name) stages.push({
       id: row.dataset.sid,
       name,
       points: pts,
       threshold,
       phase: row.dataset.phase || 'painting',
-      skippable: row.dataset.skippable !== 'false'
+      skippable: row.dataset.skippable !== 'false',
+      ...(isCrew ? { group: 'crew' } : {})
     });
   });
   return stages;


### PR DESCRIPTION
War Machines represent roughly 3 crew models plus 3 infantry-equivalent
of work on the machine itself. Scale each stage to 6x the Infantry
preset (10 -> 60 total points) instead of the old, much lower total (14).