### PR TITLE
Add Quartermaster's Office: purchase planning, valuation, and budget tracking

### DIFF
--- a/index.html
+++ b/index.html
@@ -1007,6 +1007,7 @@
     .list-completion-chart .chart-wrap { height: 220px; }
 
     .dash-pile { grid-column: 1 / -1; }
+    .dash-pile-burndown { grid-column: 1 / -1; }
     .dash-grey-brigade { grid-column: 1 / -1; }
     .pile-card-header { display: flex; align-items: center; justify-content: space-between; margin-bottom: 0.75em; }
     .pile-card-header h3 { margin-bottom: 0; }
@@ -1021,6 +1022,13 @@
     .pile-item:last-child { border-bottom: none; }
     .pile-item-name { flex: 1; }
     .pile-item-qty { color: var(--text-muted); font-size: 0.88em; margin-left: 0.5em; }
+
+    /* Quartermaster's Office */
+    .qm-sys-grid { grid-template-columns: repeat(auto-fill, minmax(140px, 1fr)); }
+    .qm-sys-card { display: flex; flex-direction: column; align-items: flex-start; gap: 0.3em; }
+    .qm-rect-figure { font-size: 1.8em; font-weight: 700; font-family: var(--font-display); }
+    .qm-rect-positive { color: var(--accent); }
+    .qm-rect-negative { color: var(--danger); }
     .pile-shame-badge { display: inline-block; font-size: 0.7em; padding: 0.1em 0.45em; border-radius: 3px; margin-left: 0.5em; font-family: var(--font-ui); white-space: nowrap; vertical-align: middle; }
     .shame-fresh { background: color-mix(in srgb, var(--text-muted) 20%, transparent); color: var(--text-muted); }
     .shame-dusty { background: color-mix(in srgb, var(--warning) 25%, transparent); color: var(--warning); }
@@ -1951,6 +1959,7 @@
       <button class="btn btn-sm" id="exportBtn" title="Export">💾</button>
       <button class="btn btn-sm" id="importBtn" title="Import">📂</button>
       <button class="btn btn-sm" id="settingsBtn" title="Settings">⚙️</button>
+      <button class="btn btn-sm" id="quartermasterBtn" title="Quartermaster's Office">🎖️</button>
       <input type="file" id="importFile" accept=".json" style="display:none">
     </div>
   </header>
@@ -2029,7 +2038,8 @@
   import { renderQueues } from './js/queue.js';
   import { renderActivity } from './js/activity.js';
   import { loadSavedTheme, applyTheme } from './js/theme.js';
-  import { toast, showModal, closeModal } from './js/ui.js';
+  import { toast, showModal, closeModal, showConfirm } from './js/ui.js';
+  import { renderQuartermaster, pileCount, pileWorth, rectitudePct } from './js/quartermaster.js';
 
   // --- Boot ---
   loadData();
@@ -2076,6 +2086,24 @@
     showModal({ title: '⚙️ Settings', content, wide: false });
     renderSettings(content);
   });
+  // --- Quartermaster's Office (modal, not a tab — always reminds before entering) ---
+  document.getElementById('quartermasterBtn').addEventListener('click', () => {
+    const count = pileCount();
+    const worth = pileWorth();
+    const rect = rectitudePct();
+    showConfirm({
+      message: `You currently have <b>${count}</b> model${count !== 1 ? 's' : ''} on the pile, worth <b>£${worth.toFixed(0)}</b>.` +
+        (rect === null ? '' : ` Rectitude: <b>${Math.round(rect)}%</b>.`),
+      confirmLabel: 'Enter',
+      onConfirm: () => {
+        const content = document.createElement('div');
+        content.id = 'qmView';
+        showModal({ title: "🎖️ Quartermaster's Office", content, wide: true });
+        renderQuartermaster(content);
+      }
+    });
+  });
+
   document.getElementById('addModelBtn').addEventListener('click', () => showModelForm());
   document.getElementById('addFolderBtn').addEventListener('click', () => {
     const name = prompt('Folder name:');

--- a/js/charts.js
+++ b/js/charts.js
@@ -1,6 +1,6 @@
 // charts.js — all Chart.js rendering
 
-import { appData, GAME_SYSTEMS, modelPoints, modelThresholdBreakdown, stageCap, saveData } from './data.js';
+import { appData, GAME_SYSTEMS, modelPoints, modelThresholdBreakdown, stageCap, saveData, unstartedCount } from './data.js';
 
 // Track chart instances so we can destroy before re-creating
 const _charts = {};
@@ -377,6 +377,129 @@ export function renderBurndown(canvasId, models, deadline) {
         },
         y: {
           min: 0, max: totalPts || 10,
+          ticks: { color: tickColor() }, grid: { color: gridColor() },
+          title: { display: true, text: 'Points', color: tickColor() }
+        }
+      }
+    }
+  });
+}
+
+// ----------------------------------------------------------------
+// LINE: Global pile burndown — historical painting velocity (across all
+// models) projected forward to estimate when the current pile of unstarted
+// models would clear at the current rate.
+// ----------------------------------------------------------------
+
+// Trailing-window velocity + projected clear date, computed once and shared
+// by the chart and its text summary so they never disagree.
+export function pileBurndownStats() {
+  const byDay = {};
+  Object.values(appData.models).forEach(m => {
+    const stages = m.stages || appData.config.stages;
+    const skipped = m.skippedStages || [];
+    stages.forEach(s => {
+      if (skipped.includes(s.id)) return;
+      const cap = stageCap(s, m);
+      const prog = m.progress[s.id];
+      if (prog?.lastDate && prog.done > 0) {
+        const pts = Math.min(prog.done, cap) * (s.points || 1);
+        byDay[prog.lastDate] = (byDay[prog.lastDate] || 0) + pts;
+      }
+    });
+  });
+
+  const pileRemainingPoints = Object.values(appData.models)
+    .filter(m => unstartedCount(m) > 0)
+    .reduce((sum, m) => {
+      const pts = modelPoints(m);
+      return sum + Math.max(0, pts.total - pts.done);
+    }, 0);
+
+  const sortedDates = Object.keys(byDay).sort();
+  const todayStr = new Date().toISOString().split('T')[0];
+  const windowStart = new Date(Date.now() - 30 * 86400000).toISOString().split('T')[0];
+  const recentPts = sortedDates.filter(d => d >= windowStart).reduce((sum, d) => sum + byDay[d], 0);
+  const velocity = recentPts / 30;
+
+  let daysToClear = null, clearDate = null;
+  if (velocity > 0 && pileRemainingPoints > 0) {
+    daysToClear = Math.ceil(pileRemainingPoints / velocity);
+    clearDate = new Date(Date.now() + daysToClear * 86400000).toISOString().split('T')[0];
+  }
+
+  return { byDay, sortedDates, todayStr, pileRemainingPoints, velocity, daysToClear, clearDate };
+}
+
+export function renderPileBurndown(canvasId) {
+  const canvas = document.getElementById(canvasId);
+  if (!canvas) return;
+  destroyChart(canvasId);
+
+  const { byDay, sortedDates, todayStr, pileRemainingPoints, daysToClear, clearDate } = pileBurndownStats();
+
+  let cum = 0;
+  const cumulativeDates = sortedDates.map(d => { cum += byDay[d]; return { d, cum }; });
+  const totalDone = cum;
+
+  const allDates = new Set([...sortedDates, todayStr]);
+  const dateRange = [...allDates].sort();
+
+  let cumSoFar = 0;
+  const actualData = [];
+  dateRange.forEach(d => {
+    const entry = cumulativeDates.find(e => e.d === d);
+    if (entry) cumSoFar = entry.cum;
+    if (d <= todayStr) actualData.push({ x: d, y: cumSoFar });
+  });
+
+  const datasets = [{
+    label: 'Points Done',
+    data: actualData,
+    borderColor: accent(),
+    backgroundColor: accent() + '26',
+    pointRadius: 3,
+    tension: 0.3,
+    fill: true
+  }];
+
+  if (daysToClear && clearDate) {
+    datasets.push({
+      label: 'Projected pile clear',
+      data: [
+        { x: todayStr, y: totalDone },
+        { x: clearDate, y: totalDone + pileRemainingPoints }
+      ],
+      borderColor: '#c8962a',
+      borderDash: [6, 4],
+      pointRadius: 0,
+      tension: 0,
+      fill: false
+    });
+  }
+
+  _charts[canvasId] = new Chart(canvas.getContext('2d'), {
+    type: 'line',
+    data: { datasets },
+    options: {
+      responsive: true,
+      maintainAspectRatio: false,
+      plugins: {
+        legend: { labels: { color: '#ccc' } },
+        tooltip: { mode: 'index', intersect: false }
+      },
+      scales: {
+        x: {
+          type: 'time',
+          time: {
+            tooltipFormat: 'yyyy-MM-dd',
+            displayFormats: { day: 'MMM d', week: 'MMM d', month: 'MMM yyyy' }
+          },
+          ticks: { color: tickColor(), maxTicksLimit: 8 },
+          grid: { color: gridColor() }
+        },
+        y: {
+          min: 0,
           ticks: { color: tickColor() }, grid: { color: gridColor() },
           title: { display: true, text: 'Points', color: tickColor() }
         }

--- a/js/dashboard.js
+++ b/js/dashboard.js
@@ -2,7 +2,7 @@
 
 import { appData, globalStats, listStats, saveData, GAME_SYSTEMS, modelThreshold, unstartedCount } from './data.js';
 import { progressBar, toast, daysUntil, formatDate, localDateStr } from './ui.js';
-import { renderCompositionPie, renderCompletionPie, renderBurndown, renderStageBar, renderListCompletionPie, pieModeToggleHtml, wirePieModeToggle } from './charts.js';
+import { renderCompositionPie, renderCompletionPie, renderBurndown, renderStageBar, renderListCompletionPie, pieModeToggleHtml, wirePieModeToggle, renderPileBurndown, pileBurndownStats } from './charts.js';
 import { showModal, closeModal, createDateInput, getDateValue } from './ui.js';
 
 export function renderDashboard() {
@@ -99,6 +99,9 @@ export function renderDashboard() {
       <!-- Pile of Potential -->
       ${pileOfPotentialSection()}
 
+      <!-- Pile burndown -->
+      ${pileBurndownSection()}
+
       <!-- Grey Brigade -->
       ${greyBrigadeSection()}
 
@@ -138,7 +141,28 @@ export function renderDashboard() {
       const models = (list.modelIds || []).map(id => appData.models[id]).filter(Boolean);
       renderListCompletionPie(`armyPie_${list.id}`, models);
     });
+    renderPileBurndown('pileBurndownChart');
   });
+}
+
+// --- Pile burndown ---
+
+function pileBurndownSection() {
+  const { pileRemainingPoints, velocity, daysToClear, clearDate } = pileBurndownStats();
+  let summary;
+  if (!pileRemainingPoints) {
+    summary = `<p class="empty-text">Nothing left on the pile to burn down. Impressive!</p>`;
+  } else if (!daysToClear) {
+    summary = `<p class="empty-text">${pileRemainingPoints} points remain on the pile — log some progress to start projecting a clear date.</p>`;
+  } else {
+    summary = `<div class="pile-total">At ${velocity.toFixed(1)} pts/day (last 30 days), the pile clears in ~${daysToClear} days (${formatDate(clearDate, { month: 'short', day: 'numeric', year: 'numeric' })}).</div>`;
+  }
+  return `
+    <div class="dash-card dash-chart-card dash-pile-burndown">
+      <h3>Pile Burndown</h3>
+      ${summary}
+      <div class="chart-wrap"><canvas id="pileBurndownChart"></canvas></div>
+    </div>`;
 }
 
 function getWeekBounds() {
@@ -416,7 +440,7 @@ function armyCompletionSection() {
 
 // --- Pile of Potential ---
 
-function resolveGameSystemId(model) {
+export function resolveGameSystemId(model) {
   if (model.gameSystemId) return model.gameSystemId;
   // For manually created models, infer from whichever list they belong to
   for (const list of Object.values(appData.lists)) {

--- a/js/data.js
+++ b/js/data.js
@@ -355,7 +355,8 @@ export let appData = {
     weeklyGoal: 0,
     imageSize: 'small',
     pieChartMode: 'count',
-    monthlyBudgetGBP: 0
+    monthlyBudgetGBP: 0,
+    budgetPeriod: 'monthly' // 'monthly' | 'annual' — display/input preference; monthlyBudgetGBP stays the source of truth
   },
   folders: {}, // id -> { id, name, collapsed }
   queues: {},  // id -> { id, name, entries: [{id, modelId, note}] }
@@ -408,7 +409,8 @@ export function loadData() {
           weeklyGoal: parsed.config?.weeklyGoal || 0,
           imageSize: parsed.config?.imageSize || 'small',
           pieChartMode: parsed.config?.pieChartMode || 'count',
-          monthlyBudgetGBP: parsed.config?.monthlyBudgetGBP || 0
+          monthlyBudgetGBP: parsed.config?.monthlyBudgetGBP || 0,
+          budgetPeriod: parsed.config?.budgetPeriod || 'monthly'
         }
       };
     }
@@ -453,7 +455,8 @@ export function replaceData(parsed) {
       weeklyGoal: parsed.config?.weeklyGoal || 0,
       imageSize: parsed.config?.imageSize || 'small',
       pieChartMode: parsed.config?.pieChartMode || 'count',
-      monthlyBudgetGBP: parsed.config?.monthlyBudgetGBP || 0
+      monthlyBudgetGBP: parsed.config?.monthlyBudgetGBP || 0,
+      budgetPeriod: parsed.config?.budgetPeriod || 'monthly'
     }
   };
   saveData();

--- a/js/data.js
+++ b/js/data.js
@@ -354,10 +354,13 @@ export let appData = {
     modelTypeOverrides: {},
     weeklyGoal: 0,
     imageSize: 'small',
-    pieChartMode: 'count'
+    pieChartMode: 'count',
+    monthlyBudgetGBP: 0
   },
   folders: {}, // id -> { id, name, collapsed }
-  queues: {}   // id -> { id, name, entries: [{id, modelId, note}] }
+  queues: {},  // id -> { id, name, entries: [{id, modelId, note}] }
+  // id -> { id, name, gameSystemId, worth, reason, plannedMonth, collectionId, status, promotedModelId }
+  purchaseQueue: {}
 };
 
 // Convert a UTC date string (YYYY-MM-DD) to the equivalent local date string.
@@ -395,6 +398,7 @@ export function loadData() {
         sessions: (parsed.sessions || []).map(s => s.date ? { ...s, date: utcToLocal(s.date) } : s),
         folders: parsed.folders || {},
         queues: parsed.queues || {},
+        purchaseQueue: parsed.purchaseQueue || {},
         config: {
           stages: parsed.config?.stages || [...DEFAULT_STAGES],
           deadline: parsed.config?.deadline || null,
@@ -403,7 +407,8 @@ export function loadData() {
           modelTypeOverrides: parsed.config?.modelTypeOverrides || {},
           weeklyGoal: parsed.config?.weeklyGoal || 0,
           imageSize: parsed.config?.imageSize || 'small',
-          pieChartMode: parsed.config?.pieChartMode || 'count'
+          pieChartMode: parsed.config?.pieChartMode || 'count',
+          monthlyBudgetGBP: parsed.config?.monthlyBudgetGBP || 0
         }
       };
     }
@@ -438,6 +443,7 @@ export function replaceData(parsed) {
     sessions: (parsed.sessions || []).map(s => s.date ? { ...s, date: utcToLocal(s.date) } : s),
     folders: parsed.folders || {},
     queues: parsed.queues || {},
+    purchaseQueue: parsed.purchaseQueue || {},
     config: {
       stages: parsed.config?.stages || [...DEFAULT_STAGES],
       deadline: parsed.config?.deadline || null,
@@ -446,7 +452,8 @@ export function replaceData(parsed) {
       modelTypeOverrides: parsed.config?.modelTypeOverrides || {},
       weeklyGoal: parsed.config?.weeklyGoal || 0,
       imageSize: parsed.config?.imageSize || 'small',
-      pieChartMode: parsed.config?.pieChartMode || 'count'
+      pieChartMode: parsed.config?.pieChartMode || 'count',
+      monthlyBudgetGBP: parsed.config?.monthlyBudgetGBP || 0
     }
   };
   saveData();
@@ -465,7 +472,7 @@ export function getModel(id) { return appData.models[id]; }
 
 export function getAllModels() { return Object.values(appData.models); }
 
-export function createModel({ name, quantity = 1, notes = '', gameSystemId = null, stages = null, skippedStages = [], folderId = null, image = null, modelTypeId = null, crewQuantity = null }) {
+export function createModel({ name, quantity = 1, notes = '', gameSystemId = null, stages = null, skippedStages = [], folderId = null, image = null, modelTypeId = null, crewQuantity = null, worth = null, sentimentLove = null, purchaseDate = null, resaleValue = null }) {
   const id = uid();
   const modelStages = stages || appData.config.stages.map(s => ({ ...s }));
   appData.models[id] = {
@@ -474,6 +481,10 @@ export function createModel({ name, quantity = 1, notes = '', gameSystemId = nul
     skippedStages,
     modelTypeId,
     crewQuantity,
+    worth,
+    sentimentLove,
+    purchaseDate,
+    resaleValue,
     dateAdded: new Date().toISOString().slice(0, 10),
     progress: {},
     sessions: []

--- a/js/models.js
+++ b/js/models.js
@@ -446,6 +446,18 @@ export function showModelForm(editId = null, defaultFolderId = null) {
       <input id="mfCrewQty" type="number" class="form-input" min="0" value="${initialCrewQty}">
       <span class="form-hint">How many crew this particular model has</span>
     </div>
+    <div class="form-row-two">
+      <div class="form-group">
+        <label>Worth (£, optional)</label>
+        <input id="mfWorth" type="number" class="form-input" min="0" step="0.01" value="${model?.worth ?? ''}">
+        <span class="form-hint">What it cost you to buy — set once, doesn't rise with painting</span>
+      </div>
+      <div class="form-group">
+        <label>Sentiment (1-5, optional)</label>
+        <input id="mfSentiment" type="number" class="form-input" min="1" max="5" value="${model?.sentimentLove ?? ''}">
+        <span class="form-hint">How much you'd miss it — not a £ value</span>
+      </div>
+    </div>
     <div class="form-group">
       <label>Notes (optional)</label>
       <textarea id="mfNotes" class="form-input" rows="2">${model?.notes || ''}</textarea>
@@ -639,6 +651,8 @@ export function showModelForm(editId = null, defaultFolderId = null) {
     const modelTypeId = typeSelect.value || null;
     let folderId = content.querySelector('#mfFolder').value || null;
     if (folderId === '__new__') folderId = null;
+    const worth = parseFloat(content.querySelector('#mfWorth').value);
+    const sentimentLove = parseInt(content.querySelector('#mfSentiment').value);
 
     if (!name) { toast('Please enter a name', 'error'); return; }
 
@@ -648,10 +662,10 @@ export function showModelForm(editId = null, defaultFolderId = null) {
     const crewQuantity = hasCrewNow ? (parseInt(content.querySelector('#mfCrewQty').value) || 0) : null;
 
     if (editId) {
-      updateModel(editId, { name, quantity, notes, modelTypeId, folderId, stages: newStages, skippedStages: newSkipped, image: currentImage, crewQuantity });
+      updateModel(editId, { name, quantity, notes, modelTypeId, folderId, stages: newStages, skippedStages: newSkipped, image: currentImage, crewQuantity, worth: isNaN(worth) ? null : worth, sentimentLove: isNaN(sentimentLove) ? null : sentimentLove });
       toast('Updated!', 'success');
     } else {
-      createModel({ name, quantity, notes, modelTypeId, folderId, stages: newStages, skippedStages: newSkipped, image: currentImage, crewQuantity });
+      createModel({ name, quantity, notes, modelTypeId, folderId, stages: newStages, skippedStages: newSkipped, image: currentImage, crewQuantity, worth: isNaN(worth) ? null : worth, sentimentLove: isNaN(sentimentLove) ? null : sentimentLove });
       toast(`${getTerm('model')} added!`, 'success');
     }
 

--- a/js/quartermaster.js
+++ b/js/quartermaster.js
@@ -1,0 +1,391 @@
+// quartermaster.js — Quartermaster's Office: purchase planning, valuation, and budget tracking
+
+import {
+  appData, saveData, uid, unstartedCount, createModel, updateModel, GAME_SYSTEMS
+} from './data.js';
+import { resolveGameSystemId } from './dashboard.js';
+import { toast, today } from './ui.js';
+
+// --- Data helpers ---
+
+export function createPurchaseItem({ name, gameSystemId = null, worth = 0, reason = '', plannedMonth = '', collectionId = null }) {
+  const id = uid();
+  appData.purchaseQueue[id] = {
+    id, name, gameSystemId, worth, reason, plannedMonth, collectionId,
+    status: 'queued', promotedModelId: null
+  };
+  saveData();
+  return id;
+}
+
+export function updatePurchaseItem(id, fields) {
+  if (!appData.purchaseQueue[id]) return;
+  Object.assign(appData.purchaseQueue[id], fields);
+  saveData();
+}
+
+export function deletePurchaseItem(id) {
+  delete appData.purchaseQueue[id];
+  saveData();
+}
+
+// Converts a queued requisition into a real model: stamps its planned worth
+// and today's date, then keeps the requisition (marked 'purchased') so it
+// still shows up in the spend timeline.
+export function promoteToModel(id) {
+  const item = appData.purchaseQueue[id];
+  if (!item) return null;
+  const modelId = createModel({ name: item.name, gameSystemId: item.gameSystemId, quantity: 1, worth: item.worth });
+  updateModel(modelId, { purchaseDate: today() });
+  updatePurchaseItem(id, { status: 'purchased', promotedModelId: modelId });
+  return modelId;
+}
+
+// --- Calculations ---
+
+function pileModels(gameSystemId = null) {
+  return Object.values(appData.models).filter(m => {
+    if (unstartedCount(m) <= 0) return false;
+    if (gameSystemId && resolveGameSystemId(m) !== gameSystemId) return false;
+    return true;
+  });
+}
+
+export function pileCount(gameSystemId = null) {
+  return pileModels(gameSystemId).reduce((sum, m) => sum + unstartedCount(m), 0);
+}
+
+export function pileWorth(gameSystemId = null) {
+  return pileModels(gameSystemId).reduce((sum, m) => sum + (m.worth || 0), 0);
+}
+
+export function backlogScoreMonths(gameSystemId = null) {
+  const budget = appData.config.monthlyBudgetGBP || 0;
+  if (!budget) return null;
+  return pileWorth(gameSystemId) / budget;
+}
+
+// Linear "budget headroom" score: 100% with an empty pile, 0% when the pile
+// exactly equals a month of budget, unbounded (and increasingly negative)
+// beyond that. Not a reciprocal — deliberately allows negative rectitude.
+export function rectitudePct(gameSystemId = null) {
+  const budget = appData.config.monthlyBudgetGBP || 0;
+  if (!budget) return null;
+  return Math.min(100, (budget - pileWorth(gameSystemId)) / budget * 100);
+}
+
+export function costToFinish(collectionId) {
+  return Object.values(appData.purchaseQueue)
+    .filter(item => item.status === 'queued' && item.collectionId === collectionId)
+    .reduce((sum, item) => sum + (item.worth || 0), 0);
+}
+
+// Single timeline merging actual past spend (promoted items, grouped by the
+// model's purchaseDate) with planned future spend (queued items, grouped by
+// plannedMonth) — serves both the budget calendar and the monthly report.
+export function monthlySpendTimeline() {
+  const months = {};
+  const ensure = m => months[m] || (months[m] = { month: m, actualSpend: 0, plannedSpend: 0 });
+  Object.values(appData.purchaseQueue).forEach(item => {
+    if (item.status === 'purchased') {
+      const model = item.promotedModelId ? appData.models[item.promotedModelId] : null;
+      const month = (model?.purchaseDate || '').slice(0, 7);
+      if (month) ensure(month).actualSpend += item.worth || 0;
+    } else if (item.plannedMonth) {
+      ensure(item.plannedMonth).plannedSpend += item.worth || 0;
+    }
+  });
+  return Object.values(months).sort((a, b) => a.month.localeCompare(b.month));
+}
+
+function rectClass(pct) {
+  if (pct === null) return '';
+  return pct >= 0 ? 'qm-rect-positive' : 'qm-rect-negative';
+}
+
+function fmtPct(pct) {
+  return pct === null ? '—' : `${Math.round(pct)}%`;
+}
+
+// --- Render ---
+
+let activeSection = 'overview';
+
+export function renderQuartermaster(container) {
+  container.innerHTML = `
+    <div class="queue-layout">
+      <div class="queue-tabs-bar">
+        <div class="queue-tab-list">
+          <button class="queue-tab-btn ${activeSection === 'overview' ? 'active' : ''}" data-qm-section="overview">Overview</button>
+          <button class="queue-tab-btn ${activeSection === 'requisitions' ? 'active' : ''}" data-qm-section="requisitions">Requisitions</button>
+          <button class="queue-tab-btn ${activeSection === 'ledger' ? 'active' : ''}" data-qm-section="ledger">Ledger</button>
+        </div>
+      </div>
+      <div class="queue-body" id="qmBody"></div>
+    </div>
+  `;
+
+  container.querySelectorAll('[data-qm-section]').forEach(btn => {
+    btn.addEventListener('click', () => {
+      activeSection = btn.dataset.qmSection;
+      renderQuartermaster(container);
+    });
+  });
+
+  const body = container.querySelector('#qmBody');
+  if (activeSection === 'overview') renderQMOverview(body);
+  else if (activeSection === 'requisitions') renderRequisitions(body, container);
+  else renderLedger(body);
+}
+
+function renderQMOverview(body) {
+  const budget = appData.config.monthlyBudgetGBP || 0;
+  const globalRect = rectitudePct();
+  const globalWorth = pileWorth();
+  const globalCount = pileCount();
+
+  const systemIds = [...new Set(
+    Object.values(appData.models)
+      .filter(m => unstartedCount(m) > 0)
+      .map(m => resolveGameSystemId(m))
+      .filter(Boolean)
+  )];
+
+  const systemCards = systemIds.map(sysId => {
+    const sys = GAME_SYSTEMS[sysId];
+    const rect = rectitudePct(sysId);
+    const worth = pileWorth(sysId);
+    return `
+      <div class="dash-card qm-sys-card">
+        <span class="sys-tag ${sys?.theme || ''}">${sys?.shortLabel || sysId}</span>
+        <div class="qm-rect-figure ${rectClass(rect)}">${fmtPct(rect)}</div>
+        <div class="pile-total">£${worth.toFixed(0)} on the pile</div>
+      </div>`;
+  }).join('');
+
+  const collectionRows = Object.values(appData.collections).map(col => {
+    const cost = costToFinish(col.id);
+    if (!cost) return '';
+    return `<div class="pile-item"><span class="pile-item-name">${col.name}</span><span class="pile-item-qty">£${cost.toFixed(0)} to finish</span></div>`;
+  }).filter(Boolean).join('');
+
+  body.innerHTML = `
+    <div class="dash-card">
+      <h3>Global Rectitude</h3>
+      ${budget ? `
+        <div class="qm-rect-figure ${rectClass(globalRect)}">${fmtPct(globalRect)}</div>
+        <div class="pile-total">£${globalWorth.toFixed(0)} worth across ${globalCount} model${globalCount !== 1 ? 's' : ''} on the pile, vs £${budget.toFixed(0)}/month budget</div>
+      ` : `<p class="empty-text">Set a monthly budget in the Ledger to calculate rectitude.</p>`}
+    </div>
+    ${systemCards ? `<div class="dashboard-grid qm-sys-grid">${systemCards}</div>` : ''}
+    ${collectionRows ? `
+      <div class="dash-card">
+        <h3>Cost to Finish</h3>
+        <div class="pile-items">${collectionRows}</div>
+      </div>` : ''}
+  `;
+}
+
+function renderRequisitions(body, container) {
+  const items = Object.values(appData.purchaseQueue)
+    .filter(i => i.status === 'queued')
+    .sort((a, b) => (a.plannedMonth || '9999').localeCompare(b.plannedMonth || '9999'));
+
+  body.innerHTML = `
+    <div class="queue-header">
+      <h2 class="queue-name">Requisitions</h2>
+      <div class="queue-header-actions">
+        <button class="btn btn-sm btn-primary" id="qmAddItemBtn">+ Add</button>
+      </div>
+    </div>
+    ${items.length === 0 ? `
+      <div class="empty-state">
+        <p>No future purchases queued.</p>
+        <p style="font-size:0.85em;color:var(--text-muted)">Add what you're planning to buy next.</p>
+      </div>
+    ` : `
+      <div class="queue-entries">
+        ${items.map(item => requisitionCard(item)).join('')}
+      </div>
+    `}
+  `;
+
+  body.querySelector('#qmAddItemBtn')?.addEventListener('click', () => renderRequisitionForm(body, container, null));
+
+  body.querySelectorAll('[data-qm-edit]').forEach(btn => {
+    btn.addEventListener('click', () => renderRequisitionForm(body, container, btn.dataset.qmEdit));
+  });
+  body.querySelectorAll('[data-qm-promote]').forEach(btn => {
+    btn.addEventListener('click', () => {
+      const item = appData.purchaseQueue[btn.dataset.qmPromote];
+      if (!item || !confirm(`Promote "${item.name}" to a real model? This adds it to your pile.`)) return;
+      promoteToModel(item.id);
+      toast(`${item.name} promoted to your model pool!`, 'success');
+      renderRequisitions(body, container);
+    });
+  });
+  body.querySelectorAll('[data-qm-delete]').forEach(btn => {
+    btn.addEventListener('click', () => {
+      if (!confirm('Remove this requisition?')) return;
+      deletePurchaseItem(btn.dataset.qmDelete);
+      renderRequisitions(body, container);
+    });
+  });
+}
+
+function requisitionCard(item) {
+  const sys = item.gameSystemId ? GAME_SYSTEMS[item.gameSystemId] : null;
+  return `
+    <div class="queue-entry" data-item-id="${item.id}">
+      <div class="queue-entry-main">
+        <div class="queue-entry-info">
+          <div class="queue-entry-name">${item.name}</div>
+          <div class="queue-entry-qty">£${(item.worth || 0).toFixed(0)}</div>
+          ${sys ? `<span class="sys-tag ${sys.theme}">${sys.shortLabel}</span>` : ''}
+        </div>
+        ${item.reason ? `<div class="queue-entry-note">📌 ${item.reason}</div>` : ''}
+        ${item.plannedMonth ? `<div class="queue-entry-note">🗓️ ${item.plannedMonth}</div>` : ''}
+        <div class="queue-entry-actions">
+          <button class="btn btn-sm btn-primary" data-qm-promote="${item.id}">✅ Promote</button>
+          <button class="btn btn-sm" data-qm-edit="${item.id}">✏️ Edit</button>
+          <button class="btn btn-sm btn-danger" data-qm-delete="${item.id}">✕</button>
+        </div>
+      </div>
+    </div>
+  `;
+}
+
+// Add/edit form for a requisition, rendered inline in the office body (NOT
+// a nested showModal — this app's modal system only tracks one overlay at a
+// time, so opening a second modal on top of the office would silently close
+// it). Shows a live "what would promoting this do to the pile / rectitude"
+// preview as the worth field changes — nothing is written to appData until Save.
+function renderRequisitionForm(body, container, editId) {
+  const item = editId ? appData.purchaseQueue[editId] : null;
+  const collections = Object.values(appData.collections);
+
+  const currentWorth = pileWorth();
+  const budget = appData.config.monthlyBudgetGBP || 0;
+
+  body.innerHTML = `
+    <div class="queue-header">
+      <h2 class="queue-name">${editId ? 'Edit' : 'New'} Requisition</h2>
+      <div class="queue-header-actions">
+        <button class="btn btn-sm" id="qmFormBack">← Back</button>
+      </div>
+    </div>
+    <div class="form-group">
+      <label>Name</label>
+      <input id="qmName" type="text" class="form-input" placeholder="What are you planning to buy?" value="${item?.name || ''}">
+    </div>
+    <div class="form-row-two">
+      <div class="form-group">
+        <label>Worth (£)</label>
+        <input id="qmWorth" type="number" class="form-input" min="0" step="0.01" value="${item?.worth ?? ''}">
+      </div>
+      <div class="form-group">
+        <label>Game System</label>
+        <select id="qmGameSystem" class="form-input">
+          <option value="">— None —</option>
+          ${Object.values(GAME_SYSTEMS).map(s => `<option value="${s.id}" ${item?.gameSystemId === s.id ? 'selected' : ''}>${s.shortLabel}</option>`).join('')}
+        </select>
+      </div>
+    </div>
+    <div class="form-row-two">
+      <div class="form-group">
+        <label>Planned Month</label>
+        <input id="qmMonth" type="month" class="form-input" value="${item?.plannedMonth || ''}">
+      </div>
+      <div class="form-group">
+        <label>Army (optional)</label>
+        <select id="qmCollection" class="form-input">
+          <option value="">— None —</option>
+          ${collections.map(c => `<option value="${c.id}" ${item?.collectionId === c.id ? 'selected' : ''}>${c.name}</option>`).join('')}
+        </select>
+      </div>
+    </div>
+    <div class="form-group">
+      <label>Reason (optional)</label>
+      <textarea id="qmReason" class="form-input" rows="2">${item?.reason || ''}</textarea>
+    </div>
+    <div class="pile-total" id="qmDeltaPreview"></div>
+    <div class="modal-actions">
+      <button class="btn btn-primary" id="qmSave">${editId ? 'Update' : 'Add'} Requisition</button>
+      <button class="btn" id="qmCancel">Cancel</button>
+    </div>
+  `;
+
+  const worthInput = body.querySelector('#qmWorth');
+  const deltaEl = body.querySelector('#qmDeltaPreview');
+
+  function updateDelta() {
+    const draftWorth = parseFloat(worthInput.value) || 0;
+    const newWorth = currentWorth + draftWorth;
+    if (!budget) {
+      deltaEl.textContent = 'Set a monthly budget in the Ledger to see rectitude impact.';
+      return;
+    }
+    const newRect = Math.min(100, (budget - newWorth) / budget * 100);
+    deltaEl.innerHTML = `If promoted: pile worth £${currentWorth.toFixed(0)} → £${newWorth.toFixed(0)}. Rectitude ${fmtPct(rectitudePct())} → <span class="${rectClass(newRect)}">${fmtPct(newRect)}</span>`;
+  }
+  worthInput.addEventListener('input', updateDelta);
+  updateDelta();
+
+  if (budget && rectitudePct() < 0) {
+    toast('Your pile already exceeds a month of budget — plan carefully.', 'warning');
+  }
+
+  body.querySelector('#qmFormBack').addEventListener('click', () => renderRequisitions(body, container));
+  body.querySelector('#qmCancel').addEventListener('click', () => renderRequisitions(body, container));
+
+  body.querySelector('#qmSave').addEventListener('click', () => {
+    const name = body.querySelector('#qmName').value.trim();
+    if (!name) { toast('Please enter a name', 'error'); return; }
+    const fields = {
+      name,
+      worth: parseFloat(body.querySelector('#qmWorth').value) || 0,
+      gameSystemId: body.querySelector('#qmGameSystem').value || null,
+      plannedMonth: body.querySelector('#qmMonth').value || '',
+      collectionId: body.querySelector('#qmCollection').value || null,
+      reason: body.querySelector('#qmReason').value.trim()
+    };
+    if (editId) updatePurchaseItem(editId, fields);
+    else createPurchaseItem(fields);
+    renderRequisitions(body, container);
+  });
+}
+
+function renderLedger(body) {
+  const budget = appData.config.monthlyBudgetGBP || 0;
+  const timeline = monthlySpendTimeline();
+
+  body.innerHTML = `
+    <div class="queue-header">
+      <h2 class="queue-name">Ledger</h2>
+    </div>
+    <div class="form-group">
+      <label>Monthly Budget (£)</label>
+      <input id="qmBudgetInput" type="number" class="form-input" min="0" step="0.01" value="${budget || ''}" style="max-width:200px">
+    </div>
+    ${timeline.length === 0 ? `
+      <div class="empty-state">
+        <p>No spend history or planned purchases yet.</p>
+      </div>
+    ` : `
+      <div class="pile-items">
+        ${timeline.map(m => `
+          <div class="pile-item">
+            <span class="pile-item-name">${m.month}</span>
+            <span class="pile-item-qty">${m.actualSpend ? `£${m.actualSpend.toFixed(0)} spent` : ''}${m.actualSpend && m.plannedSpend ? ' · ' : ''}${m.plannedSpend ? `£${m.plannedSpend.toFixed(0)} planned` : ''}</span>
+          </div>
+        `).join('')}
+      </div>
+    `}
+  `;
+
+  body.querySelector('#qmBudgetInput').addEventListener('change', e => {
+    appData.config.monthlyBudgetGBP = parseFloat(e.target.value) || 0;
+    saveData();
+    toast('Budget updated', 'success');
+  });
+}

--- a/js/quartermaster.js
+++ b/js/quartermaster.js
@@ -356,17 +356,29 @@ function renderRequisitionForm(body, container, editId) {
 }
 
 function renderLedger(body) {
-  const budget = appData.config.monthlyBudgetGBP || 0;
+  const monthlyBudget = appData.config.monthlyBudgetGBP || 0;
+  const period = appData.config.budgetPeriod || 'monthly';
+  const displayAmount = period === 'annual' ? monthlyBudget * 12 : monthlyBudget;
   const timeline = monthlySpendTimeline();
 
   body.innerHTML = `
     <div class="queue-header">
       <h2 class="queue-name">Ledger</h2>
     </div>
-    <div class="form-group">
-      <label>Monthly Budget (£)</label>
-      <input id="qmBudgetInput" type="number" class="form-input" min="0" step="0.01" value="${budget || ''}" style="max-width:200px">
+    <div class="form-row-two" style="max-width:360px">
+      <div class="form-group">
+        <label>Budget (£)</label>
+        <input id="qmBudgetInput" type="number" class="form-input" min="0" step="0.01" value="${displayAmount || ''}">
+      </div>
+      <div class="form-group">
+        <label>Per</label>
+        <select id="qmBudgetPeriod" class="form-input">
+          <option value="monthly" ${period === 'monthly' ? 'selected' : ''}>Month</option>
+          <option value="annual" ${period === 'annual' ? 'selected' : ''}>Year</option>
+        </select>
+      </div>
     </div>
+    ${monthlyBudget ? `<p class="form-hint">= £${monthlyBudget.toFixed(2)}/month for rectitude</p>` : ''}
     ${timeline.length === 0 ? `
       <div class="empty-state">
         <p>No spend history or planned purchases yet.</p>
@@ -383,9 +395,21 @@ function renderLedger(body) {
     `}
   `;
 
+  // Amount changes reinterpret the figure under whichever period is currently
+  // selected; switching the period alone just converts the displayed figure
+  // (via re-render) without changing the underlying monthly budget.
   body.querySelector('#qmBudgetInput').addEventListener('change', e => {
-    appData.config.monthlyBudgetGBP = parseFloat(e.target.value) || 0;
+    const amount = parseFloat(e.target.value) || 0;
+    const selectedPeriod = body.querySelector('#qmBudgetPeriod').value;
+    appData.config.monthlyBudgetGBP = selectedPeriod === 'annual' ? amount / 12 : amount;
     saveData();
     toast('Budget updated', 'success');
+    renderLedger(body);
+  });
+
+  body.querySelector('#qmBudgetPeriod').addEventListener('change', e => {
+    appData.config.budgetPeriod = e.target.value;
+    saveData();
+    renderLedger(body);
   });
 }


### PR DESCRIPTION
Adds a secondary area (reached via a new header icon, not a main tab) for
planning future purchases and tracking their impact on the pile of unstarted
models:

- Model worth (£) and sentiment (1-5) fields, editable in the normal model
  form; worth is user-set and doesn't auto-inflate.
- A purchase-queue ("Requisitions") of planned buys with a live pile-impact
  preview and promotion into a real model once bought.
- A "rectitude" metric (budget headroom as % of monthly budget, unbounded
  below zero) shown globally and per game system, with a non-blocking
  warning when adding a purchase while the pile already exceeds budget.
- A Ledger view merging past spend and planned spend into one timeline.
- Entry always shows a reminder of the current pile size/worth/rectitude
  before opening.
- A "Pile Burndown" chart on the normal dashboard projecting, from recent
  painting velocity, when the current pile would clear.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01FtreojradipsYqW7kmmgb4