### PR TITLE
Add ledger-only requisition types: gifts, codices, sundries

### DIFF
--- a/js/data.js
+++ b/js/data.js
@@ -360,7 +360,8 @@ export let appData = {
   },
   folders: {}, // id -> { id, name, collapsed }
   queues: {},  // id -> { id, name, entries: [{id, modelId, note}] }
-  // id -> { id, name, gameSystemId, worth, reason, plannedMonth, collectionId, status, promotedModelId }
+  // id -> { id, name, gameSystemId, worth, reason, plannedMonth, collectionId, itemType, status, promotedModelId, purchaseDate }
+  // itemType: 'model' (joins the pile on promotion) | 'gift' | 'codex' | 'sundry' (ledger-only, never joins the pile)
   purchaseQueue: {}
 };
 

--- a/js/quartermaster.js
+++ b/js/quartermaster.js
@@ -8,11 +8,24 @@ import { toast, today } from './ui.js';
 
 // --- Data helpers ---
 
-export function createPurchaseItem({ name, gameSystemId = null, worth = 0, reason = '', plannedMonth = '', collectionId = null }) {
+// Requisition item types. 'model' promotes into a real model in the pool
+// (and so joins the pile / weighs on rectitude). The rest — gifts, codices,
+// sundries — are ledger-only: they're real spend for budgeting purposes,
+// but promoting them never creates a model, so they never touch the pile
+// or compromise rectitude. Promoting one of these just marks it purchased
+// and it disappears from the Requisitions list into the Ledger's spend history.
+export const PURCHASE_ITEM_TYPES = {
+  model: { id: 'model', label: 'Model / Miniature', addsToPile: true },
+  gift: { id: 'gift', label: 'Gift', addsToPile: false },
+  codex: { id: 'codex', label: 'Codex / Rulebook', addsToPile: false },
+  sundry: { id: 'sundry', label: 'Sundry / Supplies', addsToPile: false }
+};
+
+export function createPurchaseItem({ name, gameSystemId = null, worth = 0, reason = '', plannedMonth = '', collectionId = null, itemType = 'model' }) {
   const id = uid();
   appData.purchaseQueue[id] = {
-    id, name, gameSystemId, worth, reason, plannedMonth, collectionId,
-    status: 'queued', promotedModelId: null
+    id, name, gameSystemId, worth, reason, plannedMonth, collectionId, itemType,
+    status: 'queued', promotedModelId: null, purchaseDate: null
   };
   saveData();
   return id;
@@ -29,15 +42,22 @@ export function deletePurchaseItem(id) {
   saveData();
 }
 
-// Converts a queued requisition into a real model: stamps its planned worth
-// and today's date, then keeps the requisition (marked 'purchased') so it
-// still shows up in the spend timeline.
+// Converts a queued requisition into spent budget. Model-type items become
+// a real model (stamped with today's purchase date), which joins the pile.
+// Gifts, codices and sundries skip model creation entirely — they're
+// stamped purchased with today's date and just drop off the Requisitions
+// list, landing only in the Ledger's spend history.
 export function promoteToModel(id) {
   const item = appData.purchaseQueue[id];
   if (!item) return null;
+  const type = PURCHASE_ITEM_TYPES[item.itemType] || PURCHASE_ITEM_TYPES.model;
+  if (!type.addsToPile) {
+    updatePurchaseItem(id, { status: 'purchased', purchaseDate: today() });
+    return null;
+  }
   const modelId = createModel({ name: item.name, gameSystemId: item.gameSystemId, quantity: 1, worth: item.worth });
   updateModel(modelId, { purchaseDate: today() });
-  updatePurchaseItem(id, { status: 'purchased', promotedModelId: modelId });
+  updatePurchaseItem(id, { status: 'purchased', promotedModelId: modelId, purchaseDate: today() });
   return modelId;
 }
 
@@ -89,7 +109,7 @@ export function monthlySpendTimeline() {
   Object.values(appData.purchaseQueue).forEach(item => {
     if (item.status === 'purchased') {
       const model = item.promotedModelId ? appData.models[item.promotedModelId] : null;
-      const month = (model?.purchaseDate || '').slice(0, 7);
+      const month = (item.purchaseDate || model?.purchaseDate || '').slice(0, 7);
       if (month) ensure(month).actualSpend += item.worth || 0;
     } else if (item.plannedMonth) {
       ensure(item.plannedMonth).plannedSpend += item.worth || 0;
@@ -218,9 +238,14 @@ function renderRequisitions(body, container) {
   body.querySelectorAll('[data-qm-promote]').forEach(btn => {
     btn.addEventListener('click', () => {
       const item = appData.purchaseQueue[btn.dataset.qmPromote];
-      if (!item || !confirm(`Promote "${item.name}" to a real model? This adds it to your pile.`)) return;
+      if (!item) return;
+      const type = PURCHASE_ITEM_TYPES[item.itemType] || PURCHASE_ITEM_TYPES.model;
+      const confirmMsg = type.addsToPile
+        ? `Promote "${item.name}" to a real model? This adds it to your pile.`
+        : `Mark "${item.name}" as purchased? As a ${type.label.toLowerCase()}, it goes on the ledger but won't join your pile or affect rectitude.`;
+      if (!confirm(confirmMsg)) return;
       promoteToModel(item.id);
-      toast(`${item.name} promoted to your model pool!`, 'success');
+      toast(type.addsToPile ? `${item.name} promoted to your model pool!` : `${item.name} logged as purchased.`, 'success');
       renderRequisitions(body, container);
     });
   });
@@ -235,6 +260,7 @@ function renderRequisitions(body, container) {
 
 function requisitionCard(item) {
   const sys = item.gameSystemId ? GAME_SYSTEMS[item.gameSystemId] : null;
+  const type = PURCHASE_ITEM_TYPES[item.itemType] || PURCHASE_ITEM_TYPES.model;
   return `
     <div class="queue-entry" data-item-id="${item.id}">
       <div class="queue-entry-main">
@@ -242,11 +268,12 @@ function requisitionCard(item) {
           <div class="queue-entry-name">${item.name}</div>
           <div class="queue-entry-qty">£${(item.worth || 0).toFixed(0)}</div>
           ${sys ? `<span class="sys-tag ${sys.theme}">${sys.shortLabel}</span>` : ''}
+          ${!type.addsToPile ? `<span class="sys-tag theme-default">${type.label}</span>` : ''}
         </div>
         ${item.reason ? `<div class="queue-entry-note">📌 ${item.reason}</div>` : ''}
         ${item.plannedMonth ? `<div class="queue-entry-note">🗓️ ${item.plannedMonth}</div>` : ''}
         <div class="queue-entry-actions">
-          <button class="btn btn-sm btn-primary" data-qm-promote="${item.id}">✅ Promote</button>
+          <button class="btn btn-sm btn-primary" data-qm-promote="${item.id}">${type.addsToPile ? '✅ Promote' : '✅ Log Purchase'}</button>
           <button class="btn btn-sm" data-qm-edit="${item.id}">✏️ Edit</button>
           <button class="btn btn-sm btn-danger" data-qm-delete="${item.id}">✕</button>
         </div>
@@ -284,26 +311,33 @@ function renderRequisitionForm(body, container, editId) {
         <input id="qmWorth" type="number" class="form-input" min="0" step="0.01" value="${item?.worth ?? ''}">
       </div>
       <div class="form-group">
+        <label>Type</label>
+        <select id="qmItemType" class="form-input">
+          ${Object.values(PURCHASE_ITEM_TYPES).map(t => `<option value="${t.id}" ${(item?.itemType || 'model') === t.id ? 'selected' : ''}>${t.label}</option>`).join('')}
+        </select>
+      </div>
+    </div>
+    <div class="form-row-two">
+      <div class="form-group">
         <label>Game System</label>
         <select id="qmGameSystem" class="form-input">
           <option value="">— None —</option>
           ${Object.values(GAME_SYSTEMS).map(s => `<option value="${s.id}" ${item?.gameSystemId === s.id ? 'selected' : ''}>${s.shortLabel}</option>`).join('')}
         </select>
       </div>
-    </div>
-    <div class="form-row-two">
       <div class="form-group">
         <label>Planned Month</label>
         <input id="qmMonth" type="month" class="form-input" value="${item?.plannedMonth || ''}">
       </div>
-      <div class="form-group">
-        <label>Army (optional)</label>
-        <select id="qmCollection" class="form-input">
-          <option value="">— None —</option>
-          ${collections.map(c => `<option value="${c.id}" ${item?.collectionId === c.id ? 'selected' : ''}>${c.name}</option>`).join('')}
-        </select>
-      </div>
     </div>
+    <div class="form-group">
+      <label>Army (optional)</label>
+      <select id="qmCollection" class="form-input">
+        <option value="">— None —</option>
+        ${collections.map(c => `<option value="${c.id}" ${item?.collectionId === c.id ? 'selected' : ''}>${c.name}</option>`).join('')}
+      </select>
+    </div>
+    <p class="form-hint" id="qmTypeHint"></p>
     <div class="form-group">
       <label>Reason (optional)</label>
       <textarea id="qmReason" class="form-input" rows="2">${item?.reason || ''}</textarea>
@@ -316,9 +350,18 @@ function renderRequisitionForm(body, container, editId) {
   `;
 
   const worthInput = body.querySelector('#qmWorth');
+  const typeSelect = body.querySelector('#qmItemType');
   const deltaEl = body.querySelector('#qmDeltaPreview');
+  const typeHintEl = body.querySelector('#qmTypeHint');
 
   function updateDelta() {
+    const type = PURCHASE_ITEM_TYPES[typeSelect.value] || PURCHASE_ITEM_TYPES.model;
+    if (!type.addsToPile) {
+      deltaEl.textContent = '';
+      typeHintEl.textContent = `${type.label} items go on the ledger but never join the pile — rectitude is unaffected.`;
+      return;
+    }
+    typeHintEl.textContent = '';
     const draftWorth = parseFloat(worthInput.value) || 0;
     const newWorth = currentWorth + draftWorth;
     if (!budget) {
@@ -329,6 +372,7 @@ function renderRequisitionForm(body, container, editId) {
     deltaEl.innerHTML = `If promoted: pile worth £${currentWorth.toFixed(0)} → £${newWorth.toFixed(0)}. Rectitude ${fmtPct(rectitudePct())} → <span class="${rectClass(newRect)}">${fmtPct(newRect)}</span>`;
   }
   worthInput.addEventListener('input', updateDelta);
+  typeSelect.addEventListener('change', updateDelta);
   updateDelta();
 
   if (budget && rectitudePct() < 0) {
@@ -344,6 +388,7 @@ function renderRequisitionForm(body, container, editId) {
     const fields = {
       name,
       worth: parseFloat(body.querySelector('#qmWorth').value) || 0,
+      itemType: body.querySelector('#qmItemType').value || 'model',
       gameSystemId: body.querySelector('#qmGameSystem').value || null,
       plannedMonth: body.querySelector('#qmMonth').value || '',
       collectionId: body.querySelector('#qmCollection').value || null,

--- a/js/quartermaster.js
+++ b/js/quartermaster.js
@@ -118,6 +118,17 @@ export function monthlySpendTimeline() {
   return Object.values(months).sort((a, b) => a.month.localeCompare(b.month));
 }
 
+// This calendar month's budget minus what's already spent and what's
+// planned to be spent this month — i.e. the uncommitted headroom left.
+export function budgetRemainingThisMonth() {
+  const budget = appData.config.monthlyBudgetGBP || 0;
+  const thisMonth = today().slice(0, 7);
+  const entry = monthlySpendTimeline().find(m => m.month === thisMonth);
+  const spent = entry?.actualSpend || 0;
+  const planned = entry?.plannedSpend || 0;
+  return { budget, spent, planned, remaining: budget - spent - planned };
+}
+
 function rectClass(pct) {
   if (pct === null) return '';
   return pct >= 0 ? 'qm-rect-positive' : 'qm-rect-negative';
@@ -405,6 +416,7 @@ function renderLedger(body) {
   const period = appData.config.budgetPeriod || 'monthly';
   const displayAmount = period === 'annual' ? monthlyBudget * 12 : monthlyBudget;
   const timeline = monthlySpendTimeline();
+  const remain = budgetRemainingThisMonth();
 
   body.innerHTML = `
     <div class="queue-header">
@@ -424,6 +436,13 @@ function renderLedger(body) {
       </div>
     </div>
     ${monthlyBudget ? `<p class="form-hint">= £${monthlyBudget.toFixed(2)}/month for rectitude</p>` : ''}
+    ${monthlyBudget ? `
+      <div class="dash-card">
+        <h3>Remaining This Month</h3>
+        <div class="qm-rect-figure ${rectClass(remain.remaining)}">£${remain.remaining.toFixed(0)}</div>
+        <div class="pile-total">£${remain.spent.toFixed(0)} spent${remain.planned ? ` + £${remain.planned.toFixed(0)} planned` : ''} of £${remain.budget.toFixed(0)} budget</div>
+      </div>
+    ` : ''}
     ${timeline.length === 0 ? `
       <div class="empty-state">
         <p>No spend history or planned purchases yet.</p>

--- a/js/quartermaster.js
+++ b/js/quartermaster.js
@@ -126,15 +126,31 @@ export function monthlySpendTimeline() {
   return Object.values(months).sort((a, b) => a.month.localeCompare(b.month));
 }
 
-// This calendar month's budget minus what's already spent and what's
-// planned to be spent this month — i.e. the uncommitted headroom left.
-export function budgetRemainingThisMonth() {
-  const budget = appData.config.monthlyBudgetGBP || 0;
+// Uncommitted headroom left against the budget, scoped to whichever period
+// the budget is actually managed in (appData.config.budgetPeriod): this
+// calendar month's budget minus this month's spend when managed monthly,
+// or this calendar year's budget minus this year's spend when managed
+// annually — comparing an annual budget against only one month's spend
+// would be meaningless.
+export function budgetRemaining() {
+  const monthlyBudget = appData.config.monthlyBudgetGBP || 0;
+  const period = appData.config.budgetPeriod || 'monthly';
+  const timeline = monthlySpendTimeline();
+
+  if (period === 'annual') {
+    const year = new Date().getFullYear();
+    const yearEntries = timeline.filter(m => m.month.startsWith(`${year}-`));
+    const budget = monthlyBudget * 12;
+    const spent = yearEntries.reduce((sum, m) => sum + m.actualSpend, 0);
+    const planned = yearEntries.reduce((sum, m) => sum + m.plannedSpend, 0);
+    return { period, budget, spent, planned, remaining: budget - spent - planned };
+  }
+
   const thisMonth = today().slice(0, 7);
-  const entry = monthlySpendTimeline().find(m => m.month === thisMonth);
+  const entry = timeline.find(m => m.month === thisMonth);
   const spent = entry?.actualSpend || 0;
   const planned = entry?.plannedSpend || 0;
-  return { budget, spent, planned, remaining: budget - spent - planned };
+  return { period, budget: monthlyBudget, spent, planned, remaining: monthlyBudget - spent - planned };
 }
 
 // All-time actual (purchased) spend, broken down by requisition type —
@@ -473,7 +489,7 @@ function renderLedger(body) {
   const period = appData.config.budgetPeriod || 'monthly';
   const displayAmount = period === 'annual' ? monthlyBudget * 12 : monthlyBudget;
   const timeline = monthlySpendTimeline();
-  const remain = budgetRemainingThisMonth();
+  const remain = budgetRemaining();
   const currentYear = new Date().getFullYear();
   const ytd = yearToDateSpend(currentYear);
   const byType = spendByType();
@@ -501,15 +517,17 @@ function renderLedger(body) {
     ${monthlyBudget ? `<p class="form-hint">= £${monthlyBudget.toFixed(2)}/month for rectitude</p>` : ''}
     ${monthlyBudget ? `
       <div class="dash-card">
-        <h3>Remaining This Month</h3>
+        <h3>Remaining This ${period === 'annual' ? 'Year' : 'Month'}</h3>
         <div class="qm-rect-figure ${rectClass(remain.remaining)}">£${remain.remaining.toFixed(0)}</div>
         <div class="pile-total">£${remain.spent.toFixed(0)} spent${remain.planned ? ` + £${remain.planned.toFixed(0)} planned` : ''} of £${remain.budget.toFixed(0)} budget</div>
       </div>
     ` : ''}
-    <div class="dash-card">
-      <h3>Year to Date (${currentYear})</h3>
-      <div class="pile-total">£${ytd.toFixed(0)} spent${monthlyBudget ? ` vs £${(monthlyBudget * 12).toFixed(0)} annual budget` : ''}</div>
-    </div>
+    ${period === 'monthly' ? `
+      <div class="dash-card">
+        <h3>Year to Date (${currentYear})</h3>
+        <div class="pile-total">£${ytd.toFixed(0)} spent${monthlyBudget ? ` vs £${(monthlyBudget * 12).toFixed(0)} annual budget` : ''}</div>
+      </div>
+    ` : ''}
     ${typeRows.length > 0 ? `
       <div class="dash-card">
         <h3>Spend by Type</h3>

--- a/js/quartermaster.js
+++ b/js/quartermaster.js
@@ -103,16 +103,24 @@ export function costToFinish(collectionId) {
 // Single timeline merging actual past spend (promoted items, grouped by the
 // model's purchaseDate) with planned future spend (queued items, grouped by
 // plannedMonth) — serves both the budget calendar and the monthly report.
+// Each month also keeps the individual items behind it (actualItems /
+// plannedItems) so the Ledger can itemize, not just show a monthly total.
 export function monthlySpendTimeline() {
   const months = {};
-  const ensure = m => months[m] || (months[m] = { month: m, actualSpend: 0, plannedSpend: 0 });
+  const ensure = m => months[m] || (months[m] = { month: m, actualSpend: 0, plannedSpend: 0, actualItems: [], plannedItems: [] });
   Object.values(appData.purchaseQueue).forEach(item => {
     if (item.status === 'purchased') {
       const model = item.promotedModelId ? appData.models[item.promotedModelId] : null;
       const month = (item.purchaseDate || model?.purchaseDate || '').slice(0, 7);
-      if (month) ensure(month).actualSpend += item.worth || 0;
+      if (month) {
+        const entry = ensure(month);
+        entry.actualSpend += item.worth || 0;
+        entry.actualItems.push(item);
+      }
     } else if (item.plannedMonth) {
-      ensure(item.plannedMonth).plannedSpend += item.worth || 0;
+      const entry = ensure(item.plannedMonth);
+      entry.plannedSpend += item.worth || 0;
+      entry.plannedItems.push(item);
     }
   });
   return Object.values(months).sort((a, b) => a.month.localeCompare(b.month));
@@ -127,6 +135,26 @@ export function budgetRemainingThisMonth() {
   const spent = entry?.actualSpend || 0;
   const planned = entry?.plannedSpend || 0;
   return { budget, spent, planned, remaining: budget - spent - planned };
+}
+
+// All-time actual (purchased) spend, broken down by requisition type —
+// how much has gone to models vs. gifts vs. codices vs. sundries.
+export function spendByType() {
+  const totals = {};
+  Object.values(appData.purchaseQueue).forEach(item => {
+    if (item.status !== 'purchased') return;
+    const t = item.itemType || 'model';
+    totals[t] = (totals[t] || 0) + (item.worth || 0);
+  });
+  return totals;
+}
+
+// Actual spend across the given calendar year (defaults to this year).
+export function yearToDateSpend(year = new Date().getFullYear()) {
+  const prefix = `${year}-`;
+  return monthlySpendTimeline()
+    .filter(m => m.month.startsWith(prefix))
+    .reduce((sum, m) => sum + m.actualSpend, 0);
 }
 
 function rectClass(pct) {
@@ -411,12 +439,47 @@ function renderRequisitionForm(body, container, editId) {
   });
 }
 
+// A month's summary row from monthlySpendTimeline(), expandable (via native
+// <details>) into its individual purchased/planned items when there are any.
+function monthRow(m) {
+  const summaryInner = `
+    <div class="pile-item">
+      <span class="pile-item-name">${m.month}</span>
+      <span class="pile-item-qty">${m.actualSpend ? `£${m.actualSpend.toFixed(0)} spent` : ''}${m.actualSpend && m.plannedSpend ? ' · ' : ''}${m.plannedSpend ? `£${m.plannedSpend.toFixed(0)} planned` : ''}</span>
+    </div>
+  `;
+  const items = [...m.actualItems.map(i => itemRow(i, 'spent')), ...m.plannedItems.map(i => itemRow(i, 'planned'))];
+  if (items.length === 0) return summaryInner;
+  return `
+    <details>
+      <summary style="cursor:pointer">${summaryInner}</summary>
+      <div style="padding-left:1.2em">${items.join('')}</div>
+    </details>
+  `;
+}
+
+function itemRow(item, kind) {
+  const type = PURCHASE_ITEM_TYPES[item.itemType] || PURCHASE_ITEM_TYPES.model;
+  return `
+    <div class="pile-item" style="font-size:0.85em">
+      <span class="pile-item-name">${item.name} <span class="form-hint" style="display:inline">${type.label}</span></span>
+      <span class="pile-item-qty">£${(item.worth || 0).toFixed(0)} ${kind}</span>
+    </div>
+  `;
+}
+
 function renderLedger(body) {
   const monthlyBudget = appData.config.monthlyBudgetGBP || 0;
   const period = appData.config.budgetPeriod || 'monthly';
   const displayAmount = period === 'annual' ? monthlyBudget * 12 : monthlyBudget;
   const timeline = monthlySpendTimeline();
   const remain = budgetRemainingThisMonth();
+  const currentYear = new Date().getFullYear();
+  const ytd = yearToDateSpend(currentYear);
+  const byType = spendByType();
+  const typeRows = Object.values(PURCHASE_ITEM_TYPES)
+    .map(t => ({ ...t, total: byType[t.id] || 0 }))
+    .filter(t => t.total > 0);
 
   body.innerHTML = `
     <div class="queue-header">
@@ -443,18 +506,25 @@ function renderLedger(body) {
         <div class="pile-total">£${remain.spent.toFixed(0)} spent${remain.planned ? ` + £${remain.planned.toFixed(0)} planned` : ''} of £${remain.budget.toFixed(0)} budget</div>
       </div>
     ` : ''}
+    <div class="dash-card">
+      <h3>Year to Date (${currentYear})</h3>
+      <div class="pile-total">£${ytd.toFixed(0)} spent${monthlyBudget ? ` vs £${(monthlyBudget * 12).toFixed(0)} annual budget` : ''}</div>
+    </div>
+    ${typeRows.length > 0 ? `
+      <div class="dash-card">
+        <h3>Spend by Type</h3>
+        <div class="pile-items">
+          ${typeRows.map(t => `<div class="pile-item"><span class="pile-item-name">${t.label}</span><span class="pile-item-qty">£${t.total.toFixed(0)}</span></div>`).join('')}
+        </div>
+      </div>
+    ` : ''}
     ${timeline.length === 0 ? `
       <div class="empty-state">
         <p>No spend history or planned purchases yet.</p>
       </div>
     ` : `
       <div class="pile-items">
-        ${timeline.map(m => `
-          <div class="pile-item">
-            <span class="pile-item-name">${m.month}</span>
-            <span class="pile-item-qty">${m.actualSpend ? `£${m.actualSpend.toFixed(0)} spent` : ''}${m.actualSpend && m.plannedSpend ? ' · ' : ''}${m.plannedSpend ? `£${m.plannedSpend.toFixed(0)} planned` : ''}</span>
-          </div>
-        `).join('')}
+        ${timeline.map(m => monthRow(m)).join('')}
       </div>
     `}
   `;


### PR DESCRIPTION
These promote straight to "purchased" without ever creating a model,
so they count toward budget spend but never join the pile or weigh
on rectitude — only Model-type requisitions still do that.