### PR TITLE
Redesign pictograms: group by model type color, size by hobby points, click for type

### DIFF
--- a/index.html
+++ b/index.html
@@ -37,10 +37,16 @@
       --chart-remain: #2a2a40;
       --header-bg:    linear-gradient(135deg, #0f3460 0%, #16213e 100%);
       --tab-active-bg:#1e2140;
-      --fig-unstarted-fill:   #f2f1f8;
-      --fig-unstarted-stroke: #4a4a70;
-      --fig-grey-fill:        #9a9aa8;
-      --fig-grey-stroke:      #5c5c6e;
+      /* Pictogram model-group colors — fixed categorical order, validated for
+         CVD-safe adjacent contrast against this app's dark surfaces. */
+      --grp-infantry:   #3987e5;
+      --grp-mounted:    #d95926;
+      --grp-large:      #199e70;
+      --grp-characters: #c98500;
+      --grp-vehicles:   #d55181;
+      --grp-special:    #008300;
+      --grp-custom:     #9085e9;
+      --grp-other:      #e66767;
     }
 
     /* ================================================================
@@ -1054,18 +1060,25 @@
     .ledger-row-planned { opacity: 0.75; }
 
     .pictograph-divider { border: none; border-top: 1px dashed var(--border); margin: 0.75em 0 0.7em; }
-    .picto-row { margin-bottom: 0.7em; }
-    .picto-row:last-child { margin-bottom: 0; }
-    .picto-row-label { display: flex; justify-content: space-between; align-items: baseline; font-size: 0.8em; margin-bottom: 0.3em; }
-    .picto-row-label .count { color: var(--text-muted); font-variant-numeric: tabular-nums; }
-    .picto-figs { display: flex; flex-wrap: wrap; gap: 2px; align-items: center; }
-    .picto-figs .fig:nth-child(10n) { margin-right: 7px; }
-    .fig { display: block; overflow: visible; cursor: default; flex-shrink: 0; stroke-width: 1; }
-    .fig-unstarted { fill: var(--fig-unstarted-fill); stroke: var(--fig-unstarted-stroke); }
-    .fig-grey { fill: var(--fig-grey-fill); stroke: var(--fig-grey-stroke); }
-    .fig:hover { stroke: var(--accent); stroke-width: 1.4; }
+    .picto-figs { display: flex; flex-wrap: wrap; gap: 3px; align-items: flex-end; }
+    .fig { display: block; overflow: visible; cursor: pointer; flex-shrink: 0; stroke-width: 1; transition: transform 0.1s ease; }
+    .fig:hover { stroke: var(--accent); stroke-width: 1.6; transform: translateY(-1px); }
+    .fig:focus-visible { outline: 2px solid var(--accent); outline-offset: 1px; }
+    /* Grey Brigade figures keep the same group-color fill as Pile of Potential,
+       just washed out, so the two piles still read as visually distinct. */
+    .fig-grey { opacity: 0.62; }
+    .fig-grp-infantry   { fill: var(--grp-infantry);   stroke: color-mix(in srgb, var(--grp-infantry) 55%, black); }
+    .fig-grp-mounted    { fill: var(--grp-mounted);    stroke: color-mix(in srgb, var(--grp-mounted) 55%, black); }
+    .fig-grp-large      { fill: var(--grp-large);      stroke: color-mix(in srgb, var(--grp-large) 55%, black); }
+    .fig-grp-characters { fill: var(--grp-characters); stroke: color-mix(in srgb, var(--grp-characters) 55%, black); }
+    .fig-grp-vehicles   { fill: var(--grp-vehicles);   stroke: color-mix(in srgb, var(--grp-vehicles) 55%, black); }
+    .fig-grp-special    { fill: var(--grp-special);    stroke: color-mix(in srgb, var(--grp-special) 55%, black); }
+    .fig-grp-custom     { fill: var(--grp-custom);     stroke: color-mix(in srgb, var(--grp-custom) 55%, black); }
+    .fig-grp-other      { fill: var(--grp-other);      stroke: color-mix(in srgb, var(--grp-other) 55%, black); }
     .picto-overflow { font-size: 0.72em; color: var(--text-muted); border: 1px solid var(--border); border-radius: 4px; padding: 0.15em 0.4em; align-self: center; }
-    .pictograph-legend { display: flex; align-items: center; gap: 0.4em; font-size: 0.78em; color: var(--text-muted); margin-top: 0.85em; }
+    .pictograph-legend { display: flex; align-items: center; flex-wrap: wrap; gap: 0.6em; font-size: 0.78em; color: var(--text-muted); margin-top: 0.85em; }
+    .picto-legend-item { display: inline-flex; align-items: center; gap: 0.3em; }
+    .picto-legend-size-note { font-style: italic; }
 
     .session-list { display: flex; flex-direction: column; gap: 0.5em; }
     .session-item { padding: 0.5em; background: var(--surface2); border-radius: var(--radius); font-size: 0.85em; }

--- a/index.html
+++ b/index.html
@@ -1022,8 +1022,12 @@
     .pile-card-header { display: flex; align-items: center; justify-content: space-between; margin-bottom: 0.75em; }
     .pile-card-header h3 { margin-bottom: 0; }
     .pile-total { font-size: 0.9em; color: var(--text-muted); margin-bottom: 0.75em; }
-    .pile-groups { display: flex; flex-wrap: wrap; gap: 1.25rem; }
-    .pile-system-group { flex: 1 1 180px; min-width: 150px; }
+    .pile-groups { display: flex; flex-wrap: wrap; align-items: stretch; gap: 1.25rem; }
+    .pile-system-group { flex: 1 1 180px; min-width: 150px; display: flex; flex-direction: column; }
+    /* Pinned to the bottom of the column (via the stretch above) so every
+       system's pictogram pile starts on the same shared line, regardless of
+       how many text rows its item list has above it. */
+    .pile-system-group .pictograph-divider { margin-top: auto; }
     .pile-system-header { display: flex; align-items: center; gap: 0.5em; margin-bottom: 0.4em; }
     .pile-system-count { font-size: 0.78em; color: var(--text-muted); }
     .pile-system-label { font-size: 0.8em; color: var(--text-muted); font-weight: 600; text-transform: uppercase; letter-spacing: 0.04em; }

--- a/index.html
+++ b/index.html
@@ -1066,6 +1066,12 @@
     .pictograph-divider { border: none; border-top: 1px dashed var(--border); margin: 0.75em 0 0.7em; }
     .picto-figs { display: flex; flex-wrap: wrap; gap: 3px; align-items: flex-end; }
     .fig { display: block; overflow: visible; cursor: pointer; flex-shrink: 0; stroke-width: 1; transition: transform 0.1s ease; }
+    /* On touch devices, figures packed 3px apart are too close to tap
+       precisely — widen the gap so each figure gets its own tappable space,
+       without changing the tight desktop pile look for mouse/trackpad use. */
+    @media (pointer: coarse) {
+      .picto-figs { gap: 9px 7px; }
+    }
     .fig:hover { stroke: var(--accent); stroke-width: 1.6; transform: translateY(-1px); }
     .fig:focus-visible { outline: 2px solid var(--accent); outline-offset: 1px; }
     /* Grey Brigade figures keep the same group-color fill as Pile of Potential,

--- a/js/dashboard.js
+++ b/js/dashboard.js
@@ -1,6 +1,6 @@
 // dashboard.js — dashboard with pie charts and deadline cards
 
-import { appData, globalStats, listStats, saveData, GAME_SYSTEMS, modelThreshold, unstartedCount } from './data.js';
+import { appData, globalStats, listStats, saveData, GAME_SYSTEMS, modelThreshold, unstartedCount, modelPoints, getModelType, resolveModelGroup, MODEL_GROUP_ORDER } from './data.js';
 import { progressBar, toast, daysUntil, formatDate, localDateStr } from './ui.js';
 import { renderCompositionPie, renderCompletionPie, renderBurndown, renderStageBar, renderListCompletionPie, pieModeToggleHtml, wirePieModeToggle, renderPileBurndown, pileBurndownStats } from './charts.js';
 import { showModal, closeModal, createDateInput, getDateValue } from './ui.js';
@@ -118,6 +118,9 @@ export function renderDashboard() {
 
   // Grey Brigade share button
   document.getElementById('shareGreyBtn')?.addEventListener('click', shareGreyBrigade);
+
+  // Pictogram figures: click/Enter/Space reveals model name + type
+  wirePictoFigs(container);
 
   // Weekly goal button
   document.getElementById('setWeeklyGoalBtn')?.addEventListener('click', () => {
@@ -502,22 +505,86 @@ function shameLabel(model) {
   return { text: 'Never started', cls: 'shame-fresh' };
 }
 
-const PICTO_CAP = 100;
+const PICTO_CAP = 150;
+const FIG_MIN_W = 8;
+const FIG_MAX_W = 22;
+const FIG_ASPECT = 32 / 24; // matches the #miniFig symbol's viewBox (0 0 24 32)
 
-function pictoRowHtml(name, count, cls) {
-  const shown = Math.min(count, PICTO_CAP);
-  let figs = '';
-  for (let i = 0; i < shown; i++) {
-    figs += `<svg class="fig ${cls}" width="11" height="15"><title>${name}</title><use href="#miniFig"></use></svg>`;
+const GROUP_CLASS = {
+  'Infantry-scale': 'fig-grp-infantry',
+  'Mounted':        'fig-grp-mounted',
+  'Large':          'fig-grp-large',
+  'Characters':     'fig-grp-characters',
+  'Vehicles':       'fig-grp-vehicles',
+  'Special':        'fig-grp-special',
+  'Custom':         'fig-grp-custom',
+  'Other':          'fig-grp-other',
+};
+
+// Relative sizing is scaled against the spread of hobby points across the
+// whole collection, so a model's figure size reflects how big it is next to
+// everything else the user owns, not an absolute point value.
+function modelPointsRange() {
+  const totals = Object.values(appData.models).map(m => modelPoints(m).total || 1);
+  if (!totals.length) return { min: 1, max: 1 };
+  return { min: Math.min(...totals), max: Math.max(...totals) };
+}
+
+function figSize(pts, minPts, maxPts) {
+  if (maxPts <= minPts) return FIG_MIN_W;
+  const t = Math.sqrt(Math.max(0, Math.min(1, (pts - minPts) / (maxPts - minPts))));
+  return Math.round((FIG_MIN_W + t * (FIG_MAX_W - FIG_MIN_W)) * 10) / 10;
+}
+
+function escAttr(s) {
+  return String(s).replace(/&/g, '&amp;').replace(/"/g, '&quot;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+}
+
+// Renders every model in `entries` as one merged, flowing pile (rather than a
+// separate row per model) so figures for the same game system sit together;
+// color encodes the model group, size encodes hobby-point "bigness", and each
+// figure is clickable/focusable to reveal which model + type it represents.
+function pictoPileHtml(entries, sectionCls, minPts, maxPts) {
+  let figsHtml = '';
+  let shown = 0;
+  let totalCount = 0;
+  entries.forEach(({ model: m, count }) => {
+    totalCount += count;
+    const groupCls = GROUP_CLASS[resolveModelGroup(m)] || GROUP_CLASS.Other;
+    const type = getModelType(m.modelTypeId);
+    const name = escAttr(m.name);
+    const typeName = escAttr(type ? type.name : 'Unknown type');
+    const w = figSize(modelPoints(m).total || 1, minPts, maxPts);
+    const h = Math.round(w * FIG_ASPECT * 10) / 10;
+    for (let i = 0; i < count; i++) {
+      if (shown >= PICTO_CAP) return;
+      shown++;
+      figsHtml += `<svg class="fig ${sectionCls} ${groupCls}" width="${w}" height="${h}" tabindex="0" role="button" data-model-name="${name}" data-type-name="${typeName}"><title>${name} — ${typeName}</title><use href="#miniFig"></use></svg>`;
+    }
+  });
+  if (totalCount > PICTO_CAP) {
+    figsHtml += `<span class="picto-overflow" title="${totalCount - PICTO_CAP} more">+${totalCount - PICTO_CAP}</span>`;
   }
-  if (count > PICTO_CAP) {
-    figs += `<span class="picto-overflow" title="${name} — ${count} total">+${count - PICTO_CAP}</span>`;
-  }
-  return `
-    <div class="picto-row">
-      <div class="picto-row-label"><span class="name">${name}</span><span class="count">${count}</span></div>
-      <div class="picto-figs">${figs}</div>
-    </div>`;
+  return `<div class="picto-figs">${figsHtml}</div>`;
+}
+
+function pictoLegendHtml(entries) {
+  const present = new Set(entries.map(({ model: m }) => resolveModelGroup(m)));
+  const items = MODEL_GROUP_ORDER.filter(g => present.has(g)).map(g => `
+    <span class="picto-legend-item"><svg class="fig ${GROUP_CLASS[g]}" width="10" height="13"><use href="#miniFig"></use></svg>${g}</span>`).join('');
+  return `<div class="pictograph-legend">${items}<span class="picto-legend-size-note">larger figure = more hobby points</span></div>`;
+}
+
+// Wire click/keyboard activation on pictogram figures to reveal the model
+// name + type, since the merged pile no longer has a per-model text label.
+function wirePictoFigs(container) {
+  container.querySelectorAll('.fig[data-model-name]').forEach(fig => {
+    const reveal = () => toast(`${fig.dataset.modelName} — ${fig.dataset.typeName}`, 'info', 3200);
+    fig.addEventListener('click', reveal);
+    fig.addEventListener('keydown', e => {
+      if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); reveal(); }
+    });
+  });
 }
 
 function pileOfPotentialSection() {
@@ -539,6 +606,8 @@ function pileOfPotentialSection() {
   const sortedSystems = Object.entries(bySystem)
     .map(([sysId, entries]) => ({ sysId, entries, maxScore: entries[0].score }))
     .sort((a, b) => b.maxScore - a.maxScore);
+
+  const { min: minPts, max: maxPts } = modelPointsRange();
 
   const systemSections = sortedSystems.map(({ sysId, entries }) => {
     const sys = GAME_SYSTEMS[sysId];
@@ -562,7 +631,7 @@ function pileOfPotentialSection() {
           }).join('')}
         </div>
         <hr class="pictograph-divider">
-        ${entries.map(({ model: m, unstarted }) => pictoRowHtml(m.name, unstarted, 'fig-unstarted')).join('')}
+        ${pictoPileHtml(entries.map(({ model, unstarted }) => ({ model, count: unstarted })), 'fig-unstarted', minPts, maxPts)}
       </div>`;
   }).join('');
 
@@ -579,7 +648,7 @@ function pileOfPotentialSection() {
         : `
           <div class="pile-total${isShameHeavy ? ' shame-heavy' : ''}">💀 ${totalCount} model${totalCount !== 1 ? 's' : ''} still on the sprue</div>
           <div class="pile-groups">${systemSections}</div>
-          <div class="pictograph-legend"><svg class="fig fig-unstarted" width="13" height="18"><use href="#miniFig"></use></svg> = 1 model still boxed</div>
+          ${pictoLegendHtml(withUnstarted)}
         `
       }
     </div>`;
@@ -713,6 +782,8 @@ function greyBrigadeSection() {
     }))
     .sort((a, b) => b.total - a.total);
 
+  const { min: minPts, max: maxPts } = modelPointsRange();
+
   const systemSections = sortedSystems.map(({ sysId, entries }) => {
     const sys = GAME_SYSTEMS[sysId];
     const sysCount = entries.reduce((a, { greyCount }) => a + greyCount, 0);
@@ -732,7 +803,7 @@ function greyBrigadeSection() {
             </div>`).join('')}
         </div>
         <hr class="pictograph-divider">
-        ${entries.map(({ model: m, greyCount }) => pictoRowHtml(m.name, greyCount, 'fig-grey')).join('')}
+        ${pictoPileHtml(entries.map(({ model, greyCount }) => ({ model, count: greyCount })), 'fig-grey', minPts, maxPts)}
       </div>`;
   }).join('');
 
@@ -749,7 +820,7 @@ function greyBrigadeSection() {
         : `
           <div class="pile-total${isShameHeavy ? ' shame-heavy' : ''}">🩶 ${totalCount} model${totalCount !== 1 ? 's' : ''} assembled or primed, awaiting paint</div>
           <div class="pile-groups">${systemSections}</div>
-          <div class="pictograph-legend"><svg class="fig fig-grey" width="13" height="18"><use href="#miniFig"></use></svg> = 1 model assembled/primed, unpainted</div>
+          ${pictoLegendHtml(withGrey)}
         `
       }
     </div>`;

--- a/js/dashboard.js
+++ b/js/dashboard.js
@@ -1,6 +1,6 @@
 // dashboard.js — dashboard with pie charts and deadline cards
 
-import { appData, globalStats, listStats, saveData, GAME_SYSTEMS, modelThreshold, unstartedCount, modelPoints, getModelType, resolveModelGroup, MODEL_GROUP_ORDER } from './data.js';
+import { appData, globalStats, listStats, saveData, GAME_SYSTEMS, modelThreshold, unstartedCount, singleModelPoints, getModelType, resolveModelGroup, MODEL_GROUP_ORDER } from './data.js';
 import { progressBar, toast, daysUntil, formatDate, localDateStr } from './ui.js';
 import { renderCompositionPie, renderCompletionPie, renderBurndown, renderStageBar, renderListCompletionPie, pieModeToggleHtml, wirePieModeToggle, renderPileBurndown, pileBurndownStats } from './charts.js';
 import { showModal, closeModal, createDateInput, getDateValue } from './ui.js';
@@ -521,11 +521,12 @@ const GROUP_CLASS = {
   'Other':          'fig-grp-other',
 };
 
-// Relative sizing is scaled against the spread of hobby points across the
-// whole collection, so a model's figure size reflects how big it is next to
-// everything else the user owns, not an absolute point value.
+// Relative sizing is scaled against the spread of per-model hobby points
+// across the whole collection (a single model of each type, not a squad's
+// batch total), so a Dragon-sized entry dwarfs an Ogre, which in turn dwarfs
+// a rank-and-file infantry model — regardless of how many are in the unit.
 function modelPointsRange() {
-  const totals = Object.values(appData.models).map(m => modelPoints(m).total || 1);
+  const totals = Object.values(appData.models).map(m => singleModelPoints(m) || 1);
   if (!totals.length) return { min: 1, max: 1 };
   return { min: Math.min(...totals), max: Math.max(...totals) };
 }
@@ -554,7 +555,7 @@ function pictoPileHtml(entries, sectionCls, minPts, maxPts) {
     const type = getModelType(m.modelTypeId);
     const name = escAttr(m.name);
     const typeName = escAttr(type ? type.name : 'Unknown type');
-    const w = figSize(modelPoints(m).total || 1, minPts, maxPts);
+    const w = figSize(singleModelPoints(m) || 1, minPts, maxPts);
     const h = Math.round(w * FIG_ASPECT * 10) / 10;
     for (let i = 0; i < count; i++) {
       if (shown >= PICTO_CAP) return;

--- a/js/data.js
+++ b/js/data.js
@@ -682,6 +682,23 @@ export function modelPoints(model) {
   return { total, done, pct: total ? Math.round(done / total * 100) : 0 };
 }
 
+// Hobby points for a single copy of this model's type — unlike modelPoints(),
+// this ignores model.quantity (a squad's batch size), so a 20-strong infantry
+// entry and a lone infantry model score the same "how big is one of these".
+// Crew stages still scale by crewQuantity, since the crew is intrinsic to one
+// war machine, not a batch of separate models.
+export function singleModelPoints(model) {
+  const stages = model.stages || appData.config.stages;
+  const skipped = model.skippedStages || [];
+  let total = 0;
+  stages.forEach(s => {
+    if (skipped.includes(s.id)) return;
+    const cap = s.group === 'crew' ? (model.crewQuantity || 0) : 1;
+    total += (s.points || 1) * cap;
+  });
+  return total;
+}
+
 export function listStats(list) {
   const modelSplits = list.modelSplits || {};
   let totalPts = 0, donePts = 0;

--- a/js/data.js
+++ b/js/data.js
@@ -300,6 +300,28 @@ export function getModelType(id) {
   return getAllModelTypes().find(t => t.id === id) || null;
 }
 
+// Broad visual/organizational groupings of model types, used to color-code
+// pictograms so different kinds of models are distinguishable at a glance.
+export const TYPE_GROUPS = {
+  'Infantry-scale': ['infantry', 'swarm'],
+  'Mounted':        ['cavalry', 'monstrous_cavalry', 'jetbike', 'chariot'],
+  'Large':          ['monster', 'walker', 'behemoth'],
+  'Characters':     ['character', 'character_horse', 'character_monster'],
+  'Vehicles':       ['warmachine', 'vehicle'],
+  'Special':        ['terrain'],
+};
+
+export const MODEL_GROUP_ORDER = [...Object.keys(TYPE_GROUPS), 'Custom', 'Other'];
+
+export function resolveModelGroup(model) {
+  const type = getModelType(model.modelTypeId);
+  if (!type) return 'Other';
+  for (const [group, ids] of Object.entries(TYPE_GROUPS)) {
+    if (ids.includes(type.id)) return group;
+  }
+  return type.builtIn ? 'Other' : 'Custom';
+}
+
 export function saveModelTypeOverride(typeId, stages) {
   if (!appData.config.modelTypeOverrides) appData.config.modelTypeOverrides = {};
   appData.config.modelTypeOverrides[typeId] = stages;

--- a/js/models.js
+++ b/js/models.js
@@ -4,7 +4,7 @@ import {
   appData, createModel, updateModel, deleteModel,
   logProgress, logSession, modelPoints, modelThreshold, stageCap, uid, saveData,
   getAllModelTypes, saveCustomModelType, deleteCustomModelType,
-  saveModelTypeOverride, resetModelTypeOverride, BUILTIN_MODEL_TYPES,
+  saveModelTypeOverride, resetModelTypeOverride, BUILTIN_MODEL_TYPES, TYPE_GROUPS,
   createFolder, updateFolder, deleteFolder, getAllFolders
 } from './data.js';
 import { showModal, closeModal, toast, progressBar, thresholdBadge, stageRow, today, createDateInput, getDateValue, createTimeInput } from './ui.js';
@@ -367,15 +367,6 @@ export function showModelDetail(modelId) {
 }
 
 // --- Model form (create / edit) ---
-
-const TYPE_GROUPS = {
-  'Infantry-scale': ['infantry', 'swarm'],
-  'Mounted':        ['cavalry', 'monstrous_cavalry', 'jetbike', 'chariot'],
-  'Large':          ['monster', 'walker', 'behemoth'],
-  'Characters':     ['character', 'character_horse', 'character_monster'],
-  'Vehicles':       ['warmachine', 'vehicle'],
-  'Special':        ['terrain'],
-};
 
 function renderTypeOptions(allTypes, selectedId) {
   const builtIn = allTypes.filter(t => t.builtIn);


### PR DESCRIPTION
Pile of Potential and Grey Brigade now render one merged pile of figures per
game system instead of a separate row per model. Figures are color-coded by
model group (Infantry-scale, Mounted, Large, Characters, Vehicles, Special,
plus Custom/Other), sized relative to each model's hobby-point total, and
clickable/keyboard-activatable to reveal the model's name and type via toast.

TYPE_GROUPS moves from models.js into data.js (now shared with dashboard.js)
alongside a new resolveModelGroup() helper.