### PR TITLE
Fix Drukhari Raider/Ravager import misclassified as infantry

### DIFF
--- a/index.html
+++ b/index.html
@@ -2037,10 +2037,9 @@
   <symbol id="miniCavalry" viewBox="0 0 34 28">
     <path d="M6 15.5 L2 15 L3.5 19.5 L7 17.5 Z"></path>
     <ellipse cx="14" cy="18" rx="9" ry="4.3"></ellipse>
-    <path d="M20 15.5 L25 8.3 L28 8.7 L24.3 17 Z"></path>
-    <ellipse cx="29" cy="7" rx="3" ry="2.3"></ellipse>
-    <rect x="30.7" y="6" width="2.6" height="1.9" rx="0.5"></rect>
-    <path d="M27.3 4.6 L28.2 2.2 L29.2 4.5 Z"></path>
+    <path d="M19 17 L22.5 10.7 L25.5 11.2 L22.5 17.5 Z"></path>
+    <ellipse cx="27" cy="10" rx="5" ry="2.6" transform="rotate(-25 27 10)"></ellipse>
+    <path d="M23 8.3 L22.2 5.2 L24.6 7.8 Z"></path>
     <circle cx="14.5" cy="8.7" r="2.4"></circle>
     <rect x="12.5" y="11" width="4" height="7" rx="1.3"></rect>
     <rect x="8" y="20" width="1.9" height="7"></rect>

--- a/index.html
+++ b/index.html
@@ -2019,6 +2019,16 @@
              L9.4 23.4
              C8.3 23.2 7.4 22.6 7.4 21.6 Z"></path>
   </symbol>
+  <symbol id="miniTank" viewBox="0 0 34 20">
+    <path d="M2 18.4 L3.4 10.6 C3.7 9.5 4.8 8.7 6 8.7 H26 C27.2 8.7 28.3 9.5 28.6 10.6 L30 18.4 Z"></path>
+    <path d="M12.5 4.2 H20 a2.2 2.2 0 0 1 2.2 2.2 V9.2 H10.3 V6.4 a2.2 2.2 0 0 1 2.2 -2.2 Z"></path>
+    <rect x="25.5" y="6.6" width="8" height="2.3" rx="0.7"></rect>
+    <circle cx="6.5" cy="17.4" r="1.7"></circle>
+    <circle cx="11.3" cy="17.7" r="1.8"></circle>
+    <circle cx="16.5" cy="17.9" r="1.8"></circle>
+    <circle cx="21.3" cy="17.7" r="1.8"></circle>
+    <circle cx="26" cy="17.4" r="1.7"></circle>
+  </symbol>
 </svg>
 <div id="app">
 

--- a/index.html
+++ b/index.html
@@ -2029,6 +2029,35 @@
     <circle cx="21.3" cy="17.7" r="1.8"></circle>
     <circle cx="26" cy="17.4" r="1.7"></circle>
   </symbol>
+  <symbol id="miniSkimmer" viewBox="0 0 34 15">
+    <ellipse cx="17" cy="13.6" rx="11" ry="1"></ellipse>
+    <path d="M2 9 L6.5 6 H25.5 L31.5 9 L25.5 12 H6.5 Z"></path>
+    <path d="M23 6 L28.5 1.6 L30 2.6 L25.2 7 Z"></path>
+  </symbol>
+  <symbol id="miniCavalry" viewBox="0 0 34 28">
+    <path d="M6 15.5 L2 15 L3.5 19.5 L7 17.5 Z"></path>
+    <ellipse cx="14" cy="18" rx="9" ry="4.3"></ellipse>
+    <path d="M20 15.5 L25 8.3 L28 8.7 L24.3 17 Z"></path>
+    <ellipse cx="29" cy="7" rx="3" ry="2.3"></ellipse>
+    <rect x="30.7" y="6" width="2.6" height="1.9" rx="0.5"></rect>
+    <path d="M27.3 4.6 L28.2 2.2 L29.2 4.5 Z"></path>
+    <circle cx="14.5" cy="8.7" r="2.4"></circle>
+    <rect x="12.5" y="11" width="4" height="7" rx="1.3"></rect>
+    <rect x="8" y="20" width="1.9" height="7"></rect>
+    <rect x="11" y="20" width="1.9" height="7"></rect>
+    <rect x="19" y="20" width="1.9" height="7"></rect>
+    <rect x="22" y="20" width="1.9" height="7"></rect>
+  </symbol>
+  <symbol id="miniWalker" viewBox="0 0 26 28">
+    <rect x="10.5" y="2" width="5" height="3.2" rx="0.9"></rect>
+    <path d="M5 7 H21 L22.5 16 H3.5 Z"></path>
+    <rect x="0.5" y="7.5" width="5.5" height="5.5" rx="1.1"></rect>
+    <rect x="20" y="7.5" width="5.5" height="5.5" rx="1.1"></rect>
+    <rect x="6" y="16" width="5" height="9" rx="1"></rect>
+    <rect x="15" y="16" width="5" height="9" rx="1"></rect>
+    <rect x="4.5" y="25" width="8" height="2.6" rx="0.8"></rect>
+    <rect x="13.5" y="25" width="8" height="2.6" rx="0.8"></rect>
+  </symbol>
 </svg>
 <div id="app">
 

--- a/js/dashboard.js
+++ b/js/dashboard.js
@@ -508,9 +508,19 @@ function shameLabel(model) {
 const PICTO_CAP = 150;
 const FIG_MIN_W = 8;
 const FIG_MAX_W = 22;
-const FIG_ASPECT = 32 / 24; // matches the #miniFig symbol's viewBox (0 0 24 32)
-const VEHICLE_ASPECT = 20 / 34; // matches the #miniTank symbol's viewBox (0 0 34 20)
-const VEHICLE_SIZE_MULT = 1.6; // vehicles read as a hull silhouette, not a standing figure — scale up so they visibly dwarf infantry at the same hobby-point score
+const FIG_ASPECT = 32 / 24; // matches the #miniFig symbol's viewBox (0 0 24 32) — default for any type without its own icon
+
+// Model types with a dedicated silhouette instead of the default standing
+// figure, keyed by model type id (not group — Vehicle and Skimmer share a
+// color group but get different shapes). `mult` scales the figure up beyond
+// its points-driven size so hardware/mounts read as visibly bigger than a
+// same-scoring infantry model, not just a bigger person.
+const ICON_CONFIG = {
+  vehicle: { symbol: 'miniTank',    aspect: 20 / 34, mult: 1.6  },
+  skimmer: { symbol: 'miniSkimmer', aspect: 15 / 34, mult: 1.5  },
+  cavalry: { symbol: 'miniCavalry', aspect: 28 / 34, mult: 1.15 },
+  walker:  { symbol: 'miniWalker',  aspect: 28 / 26, mult: 1.2  },
+};
 
 const GROUP_CLASS = {
   'Infantry-scale': 'fig-grp-infantry',
@@ -553,16 +563,15 @@ function pictoPileHtml(entries, sectionCls, minPts, maxPts) {
   let totalCount = 0;
   entries.forEach(({ model: m, count }) => {
     totalCount += count;
-    const group = resolveModelGroup(m);
-    const groupCls = GROUP_CLASS[group] || GROUP_CLASS.Other;
-    const isVehicle = group === 'Vehicles';
-    const symbolId = isVehicle ? 'miniTank' : 'miniFig';
+    const groupCls = GROUP_CLASS[resolveModelGroup(m)] || GROUP_CLASS.Other;
     const type = getModelType(m.modelTypeId);
+    const icon = ICON_CONFIG[type?.id];
+    const symbolId = icon ? icon.symbol : 'miniFig';
     const name = escAttr(m.name);
     const typeName = escAttr(type ? type.name : 'Unknown type');
     let w = figSize(singleModelPoints(m) || 1, minPts, maxPts);
-    if (isVehicle) w = Math.round(w * VEHICLE_SIZE_MULT * 10) / 10;
-    const h = Math.round(w * (isVehicle ? VEHICLE_ASPECT : FIG_ASPECT) * 10) / 10;
+    if (icon) w = Math.round(w * icon.mult * 10) / 10;
+    const h = Math.round(w * (icon ? icon.aspect : FIG_ASPECT) * 10) / 10;
     for (let i = 0; i < count; i++) {
       if (shown >= PICTO_CAP) return;
       shown++;
@@ -575,13 +584,16 @@ function pictoPileHtml(entries, sectionCls, minPts, maxPts) {
   return `<div class="picto-figs">${figsHtml}</div>`;
 }
 
+// Vehicles group uses the tank shape as its representative swatch even
+// though Skimmer (also in that group) renders differently in the pile itself
+// — the legend communicates color-to-group, not every shape variant within it.
 function pictoLegendHtml(entries) {
   const present = new Set(entries.map(({ model: m }) => resolveModelGroup(m)));
   const items = MODEL_GROUP_ORDER.filter(g => present.has(g)).map(g => {
-    const isVehicle = g === 'Vehicles';
-    const w = isVehicle ? 15 : 10;
-    const h = isVehicle ? Math.round(w * VEHICLE_ASPECT * 10) / 10 : 13;
-    return `<span class="picto-legend-item"><svg class="fig ${GROUP_CLASS[g]}" width="${w}" height="${h}"><use href="#${isVehicle ? 'miniTank' : 'miniFig'}"></use></svg>${g}</span>`;
+    const icon = g === 'Vehicles' ? ICON_CONFIG.vehicle : null;
+    const w = icon ? 15 : 10;
+    const h = icon ? Math.round(w * icon.aspect * 10) / 10 : 13;
+    return `<span class="picto-legend-item"><svg class="fig ${GROUP_CLASS[g]}" width="${w}" height="${h}"><use href="#${icon ? icon.symbol : 'miniFig'}"></use></svg>${g}</span>`;
   }).join('');
   return `<div class="pictograph-legend">${items}<span class="picto-legend-size-note">larger figure = more hobby points</span></div>`;
 }

--- a/js/dashboard.js
+++ b/js/dashboard.js
@@ -509,6 +509,8 @@ const PICTO_CAP = 150;
 const FIG_MIN_W = 8;
 const FIG_MAX_W = 22;
 const FIG_ASPECT = 32 / 24; // matches the #miniFig symbol's viewBox (0 0 24 32)
+const VEHICLE_ASPECT = 20 / 34; // matches the #miniTank symbol's viewBox (0 0 34 20)
+const VEHICLE_SIZE_MULT = 1.6; // vehicles read as a hull silhouette, not a standing figure — scale up so they visibly dwarf infantry at the same hobby-point score
 
 const GROUP_CLASS = {
   'Infantry-scale': 'fig-grp-infantry',
@@ -551,16 +553,20 @@ function pictoPileHtml(entries, sectionCls, minPts, maxPts) {
   let totalCount = 0;
   entries.forEach(({ model: m, count }) => {
     totalCount += count;
-    const groupCls = GROUP_CLASS[resolveModelGroup(m)] || GROUP_CLASS.Other;
+    const group = resolveModelGroup(m);
+    const groupCls = GROUP_CLASS[group] || GROUP_CLASS.Other;
+    const isVehicle = group === 'Vehicles';
+    const symbolId = isVehicle ? 'miniTank' : 'miniFig';
     const type = getModelType(m.modelTypeId);
     const name = escAttr(m.name);
     const typeName = escAttr(type ? type.name : 'Unknown type');
-    const w = figSize(singleModelPoints(m) || 1, minPts, maxPts);
-    const h = Math.round(w * FIG_ASPECT * 10) / 10;
+    let w = figSize(singleModelPoints(m) || 1, minPts, maxPts);
+    if (isVehicle) w = Math.round(w * VEHICLE_SIZE_MULT * 10) / 10;
+    const h = Math.round(w * (isVehicle ? VEHICLE_ASPECT : FIG_ASPECT) * 10) / 10;
     for (let i = 0; i < count; i++) {
       if (shown >= PICTO_CAP) return;
       shown++;
-      figsHtml += `<svg class="fig ${sectionCls} ${groupCls}" width="${w}" height="${h}" tabindex="0" role="button" data-model-name="${name}" data-type-name="${typeName}"><title>${name} — ${typeName}</title><use href="#miniFig"></use></svg>`;
+      figsHtml += `<svg class="fig ${sectionCls} ${groupCls}" width="${w}" height="${h}" tabindex="0" role="button" data-model-name="${name}" data-type-name="${typeName}"><title>${name} — ${typeName}</title><use href="#${symbolId}"></use></svg>`;
     }
   });
   if (totalCount > PICTO_CAP) {
@@ -571,8 +577,12 @@ function pictoPileHtml(entries, sectionCls, minPts, maxPts) {
 
 function pictoLegendHtml(entries) {
   const present = new Set(entries.map(({ model: m }) => resolveModelGroup(m)));
-  const items = MODEL_GROUP_ORDER.filter(g => present.has(g)).map(g => `
-    <span class="picto-legend-item"><svg class="fig ${GROUP_CLASS[g]}" width="10" height="13"><use href="#miniFig"></use></svg>${g}</span>`).join('');
+  const items = MODEL_GROUP_ORDER.filter(g => present.has(g)).map(g => {
+    const isVehicle = g === 'Vehicles';
+    const w = isVehicle ? 15 : 10;
+    const h = isVehicle ? Math.round(w * VEHICLE_ASPECT * 10) / 10 : 13;
+    return `<span class="picto-legend-item"><svg class="fig ${GROUP_CLASS[g]}" width="${w}" height="${h}"><use href="#${isVehicle ? 'miniTank' : 'miniFig'}"></use></svg>${g}</span>`;
+  }).join('');
   return `<div class="pictograph-legend">${items}<span class="picto-legend-size-note">larger figure = more hobby points</span></div>`;
 }
 

--- a/js/data.js
+++ b/js/data.js
@@ -156,10 +156,24 @@ export const BUILTIN_MODEL_TYPES = [
     name: 'Vehicle',
     builtIn: true,
     stages: [
-      { id: 's1', name: 'Assembly',  points: 5, phase: 'assembly', skippable: false, threshold: 'table_ready' },
+      { id: 's1', name: 'Assembly',  points: 6, phase: 'assembly', skippable: false, threshold: 'table_ready' },
+      { id: 's2', name: 'Prime',     points: 3, phase: 'painting', skippable: false, threshold: null },
+      { id: 's3', name: 'Basecoat',  points: 5, phase: 'painting', skippable: false, threshold: null },
+      { id: 's4', name: 'Shade',     points: 2, phase: 'painting', skippable: false, threshold: null },
+      { id: 's5', name: 'Layer',     points: 3, phase: 'painting', skippable: true,  threshold: null },
+      { id: 's6', name: 'Highlight', points: 4, phase: 'painting', skippable: true,  threshold: 'painted' },
+      { id: 's7', name: 'Basing',    points: 2, phase: 'basing',   skippable: true,  threshold: 'finished' },
+    ]
+  },
+  {
+    id: 'monstrous_infantry',
+    name: 'Monstrous / Heavy Infantry',
+    builtIn: true,
+    stages: [
+      { id: 's1', name: 'Assembly',  points: 3, phase: 'assembly', skippable: false, threshold: 'table_ready' },
       { id: 's2', name: 'Prime',     points: 2, phase: 'painting', skippable: false, threshold: null },
       { id: 's3', name: 'Basecoat',  points: 4, phase: 'painting', skippable: false, threshold: null },
-      { id: 's4', name: 'Shade',     points: 1, phase: 'painting', skippable: false, threshold: null },
+      { id: 's4', name: 'Shade',     points: 2, phase: 'painting', skippable: false, threshold: null },
       { id: 's5', name: 'Layer',     points: 2, phase: 'painting', skippable: true,  threshold: null },
       { id: 's6', name: 'Highlight', points: 3, phase: 'painting', skippable: true,  threshold: 'painted' },
       { id: 's7', name: 'Basing',    points: 2, phase: 'basing',   skippable: true,  threshold: 'finished' },
@@ -303,7 +317,7 @@ export function getModelType(id) {
 // Broad visual/organizational groupings of model types, used to color-code
 // pictograms so different kinds of models are distinguishable at a glance.
 export const TYPE_GROUPS = {
-  'Infantry-scale': ['infantry', 'swarm'],
+  'Infantry-scale': ['infantry', 'swarm', 'monstrous_infantry'],
   'Mounted':        ['cavalry', 'monstrous_cavalry', 'jetbike', 'chariot'],
   'Large':          ['monster', 'walker', 'behemoth'],
   'Characters':     ['character', 'character_horse', 'character_monster'],

--- a/js/data.js
+++ b/js/data.js
@@ -166,6 +166,23 @@ export const BUILTIN_MODEL_TYPES = [
     ]
   },
   {
+    id: 'skimmer',
+    name: 'Skimmer',
+    builtIn: true,
+    // Functionally identical to Vehicle — same painting workload — this is
+    // purely a distinct type so anti-grav vehicles get the skimmer icon
+    // instead of the tracked-tank icon in the pile pictogram.
+    stages: [
+      { id: 's1', name: 'Assembly',  points: 6, phase: 'assembly', skippable: false, threshold: 'table_ready' },
+      { id: 's2', name: 'Prime',     points: 3, phase: 'painting', skippable: false, threshold: null },
+      { id: 's3', name: 'Basecoat',  points: 5, phase: 'painting', skippable: false, threshold: null },
+      { id: 's4', name: 'Shade',     points: 2, phase: 'painting', skippable: false, threshold: null },
+      { id: 's5', name: 'Layer',     points: 3, phase: 'painting', skippable: true,  threshold: null },
+      { id: 's6', name: 'Highlight', points: 4, phase: 'painting', skippable: true,  threshold: 'painted' },
+      { id: 's7', name: 'Basing',    points: 2, phase: 'basing',   skippable: true,  threshold: 'finished' },
+    ]
+  },
+  {
     id: 'monstrous_infantry',
     name: 'Monstrous / Heavy Infantry',
     builtIn: true,
@@ -321,7 +338,7 @@ export const TYPE_GROUPS = {
   'Mounted':        ['cavalry', 'monstrous_cavalry', 'jetbike', 'chariot'],
   'Large':          ['monster', 'walker', 'behemoth'],
   'Characters':     ['character', 'character_horse', 'character_monster'],
-  'Vehicles':       ['warmachine', 'vehicle'],
+  'Vehicles':       ['warmachine', 'vehicle', 'skimmer'],
   'Special':        ['terrain'],
 };
 

--- a/js/w40k-import.js
+++ b/js/w40k-import.js
@@ -10,7 +10,7 @@ function detectModelType(name, section) {
 
   if (/dreadnought|sentinel|armiger|knight|titan|killa kan|deff dread|gorkanaut|morkanaut/.test(n)) return 'walker';
 
-  if (/rhino|predator|land raider|repulsor|gladiator|impulsor|vindicator|razorback|chimera|hellhound|leman russ|basilisk|manticore|deathstrike|wave serpent|falcon|hammerhead|devilfish|broadside|ghostkeel|defiler|forgefiend|maulerfiend|skorpius|dunecrawler/.test(n)) return 'vehicle';
+  if (/rhino|predator|land raider|repulsor|gladiator|impulsor|vindicator|razorback|chimera|hellhound|leman russ|basilisk|manticore|deathstrike|wave serpent|falcon|hammerhead|devilfish|broadside|ghostkeel|defiler|forgefiend|maulerfiend|skorpius|dunecrawler|\braider\b|\bravager\b|venom|razorwing|voidraven|tantalus/.test(n)) return 'vehicle';
 
   if (/tyrannofex|screamer.killer|hive tyrant|carnifex|tervigon|trygon|mawloc|haruspex|exocrine|maleceptor|toxicrene|psychophage|norn emissary|daemon prince|great unclean|bloodthirster|lord of change|keeper of secrets|neurotyrant/.test(n)) return 'monster';
 

--- a/js/w40k-import.js
+++ b/js/w40k-import.js
@@ -10,7 +10,11 @@ function detectModelType(name, section) {
 
   if (/dreadnought|sentinel|armiger|knight|titan|killa kan|deff dread|gorkanaut|morkanaut/.test(n)) return 'walker';
 
-  if (/rhino|predator|land raider|repulsor|gladiator|impulsor|vindicator|razorback|chimera|hellhound|leman russ|basilisk|manticore|deathstrike|wave serpent|falcon|hammerhead|devilfish|broadside|ghostkeel|defiler|forgefiend|maulerfiend|skorpius|dunecrawler|\braider\b|\bravager\b|venom|razorwing|voidraven|tantalus/.test(n)) return 'vehicle';
+  if (/rhino|predator|land raider|repulsor|gladiator|impulsor|vindicator|razorback|chimera|hellhound|leman russ|basilisk|manticore|deathstrike|wave serpent|falcon|hammerhead|devilfish|broadside|ghostkeel|defiler|forgefiend|maulerfiend|skorpius|dunecrawler/.test(n)) return 'vehicle';
+
+  // Anti-grav skimmers (checked after the tracked-vehicle list above so
+  // "Land Raider" still matches that list's own "land raider" entry first).
+  if (/\braider\b|\bravager\b|venom|razorwing|voidraven|tantalus/.test(n)) return 'skimmer';
 
   if (/tyrannofex|screamer.killer|hive tyrant|carnifex|tervigon|trygon|mawloc|haruspex|exocrine|maleceptor|toxicrene|psychophage|norn emissary|daemon prince|great unclean|bloodthirster|lord of change|keeper of secrets|neurotyrant/.test(n)) return 'monster';
 


### PR DESCRIPTION
detectModelType() only matched "land raider" (Space Marines), so the
Drukhari Raider and Ravager skimmers fell through to the default
infantry type on import, landing in the same pictogram group/size as
unrelated infantry like Wraithguard. Add raider, ravager, venom,
razorwing, voidraven, and tantalus to the vehicle pattern.