### PR TITLE
Add Large Vehicle / Super-Heavy model type (~50 pts)

### DIFF
--- a/js/dashboard.js
+++ b/js/dashboard.js
@@ -520,6 +520,8 @@ const ICON_CONFIG = {
   large_vehicle:       { symbol: 'miniTank',    aspect: 20 / 34, mult: 2.0  },
   super_heavy_vehicle: { symbol: 'miniTank',    aspect: 20 / 34, mult: 2.6  },
   skimmer:             { symbol: 'miniSkimmer', aspect: 15 / 34, mult: 1.5  },
+  large_skimmer:       { symbol: 'miniSkimmer', aspect: 15 / 34, mult: 1.9  },
+  super_heavy_skimmer: { symbol: 'miniSkimmer', aspect: 15 / 34, mult: 2.4  },
   cavalry:             { symbol: 'miniCavalry', aspect: 28 / 34, mult: 1.15 },
   walker:              { symbol: 'miniWalker',  aspect: 28 / 26, mult: 1.2  },
 };

--- a/js/dashboard.js
+++ b/js/dashboard.js
@@ -516,10 +516,11 @@ const FIG_ASPECT = 32 / 24; // matches the #miniFig symbol's viewBox (0 0 24 32)
 // its points-driven size so hardware/mounts read as visibly bigger than a
 // same-scoring infantry model, not just a bigger person.
 const ICON_CONFIG = {
-  vehicle: { symbol: 'miniTank',    aspect: 20 / 34, mult: 1.6  },
-  skimmer: { symbol: 'miniSkimmer', aspect: 15 / 34, mult: 1.5  },
-  cavalry: { symbol: 'miniCavalry', aspect: 28 / 34, mult: 1.15 },
-  walker:  { symbol: 'miniWalker',  aspect: 28 / 26, mult: 1.2  },
+  vehicle:       { symbol: 'miniTank',    aspect: 20 / 34, mult: 1.6  },
+  large_vehicle: { symbol: 'miniTank',    aspect: 20 / 34, mult: 2.2  },
+  skimmer:       { symbol: 'miniSkimmer', aspect: 15 / 34, mult: 1.5  },
+  cavalry:       { symbol: 'miniCavalry', aspect: 28 / 34, mult: 1.15 },
+  walker:        { symbol: 'miniWalker',  aspect: 28 / 26, mult: 1.2  },
 };
 
 const GROUP_CLASS = {

--- a/js/dashboard.js
+++ b/js/dashboard.js
@@ -516,11 +516,12 @@ const FIG_ASPECT = 32 / 24; // matches the #miniFig symbol's viewBox (0 0 24 32)
 // its points-driven size so hardware/mounts read as visibly bigger than a
 // same-scoring infantry model, not just a bigger person.
 const ICON_CONFIG = {
-  vehicle:       { symbol: 'miniTank',    aspect: 20 / 34, mult: 1.6  },
-  large_vehicle: { symbol: 'miniTank',    aspect: 20 / 34, mult: 2.2  },
-  skimmer:       { symbol: 'miniSkimmer', aspect: 15 / 34, mult: 1.5  },
-  cavalry:       { symbol: 'miniCavalry', aspect: 28 / 34, mult: 1.15 },
-  walker:        { symbol: 'miniWalker',  aspect: 28 / 26, mult: 1.2  },
+  vehicle:             { symbol: 'miniTank',    aspect: 20 / 34, mult: 1.6  },
+  large_vehicle:       { symbol: 'miniTank',    aspect: 20 / 34, mult: 2.0  },
+  super_heavy_vehicle: { symbol: 'miniTank',    aspect: 20 / 34, mult: 2.6  },
+  skimmer:             { symbol: 'miniSkimmer', aspect: 15 / 34, mult: 1.5  },
+  cavalry:             { symbol: 'miniCavalry', aspect: 28 / 34, mult: 1.15 },
+  walker:              { symbol: 'miniWalker',  aspect: 28 / 26, mult: 1.2  },
 };
 
 const GROUP_CLASS = {

--- a/js/data.js
+++ b/js/data.js
@@ -166,6 +166,23 @@ export const BUILTIN_MODEL_TYPES = [
     ]
   },
   {
+    id: 'large_vehicle',
+    name: 'Large Vehicle / Super-Heavy',
+    builtIn: true,
+    // Super-heavy tanks, titans, and gargants — double the surface area of a
+    // standard Vehicle, so stage points scale up proportionally rather than
+    // just being an arbitrary round number.
+    stages: [
+      { id: 's1', name: 'Assembly',  points: 12, phase: 'assembly', skippable: false, threshold: 'table_ready' },
+      { id: 's2', name: 'Prime',     points: 6,  phase: 'painting', skippable: false, threshold: null },
+      { id: 's3', name: 'Basecoat',  points: 10, phase: 'painting', skippable: false, threshold: null },
+      { id: 's4', name: 'Shade',     points: 4,  phase: 'painting', skippable: false, threshold: null },
+      { id: 's5', name: 'Layer',     points: 6,  phase: 'painting', skippable: true,  threshold: null },
+      { id: 's6', name: 'Highlight', points: 8,  phase: 'painting', skippable: true,  threshold: 'painted' },
+      { id: 's7', name: 'Basing',    points: 4,  phase: 'basing',   skippable: true,  threshold: 'finished' },
+    ]
+  },
+  {
     id: 'skimmer',
     name: 'Skimmer',
     builtIn: true,
@@ -338,7 +355,7 @@ export const TYPE_GROUPS = {
   'Mounted':        ['cavalry', 'monstrous_cavalry', 'jetbike', 'chariot'],
   'Large':          ['monster', 'walker', 'behemoth'],
   'Characters':     ['character', 'character_horse', 'character_monster'],
-  'Vehicles':       ['warmachine', 'vehicle', 'skimmer'],
+  'Vehicles':       ['warmachine', 'vehicle', 'skimmer', 'large_vehicle'],
   'Special':        ['terrain'],
 };
 

--- a/js/data.js
+++ b/js/data.js
@@ -199,11 +199,11 @@ export const BUILTIN_MODEL_TYPES = [
   },
   {
     id: 'skimmer',
-    name: 'Skimmer',
+    name: 'Light Skimmer',
     builtIn: true,
-    // Functionally identical to Vehicle — same painting workload — this is
-    // purely a distinct type so anti-grav vehicles get the skimmer icon
-    // instead of the tracked-tank icon in the pile pictogram.
+    // Functionally identical to Light Vehicle — same painting workload —
+    // this is purely a distinct type so anti-grav vehicles get the skimmer
+    // icon instead of the tracked-tank icon in the pile pictogram.
     stages: [
       { id: 's1', name: 'Assembly',  points: 6, phase: 'assembly', skippable: false, threshold: 'table_ready' },
       { id: 's2', name: 'Prime',     points: 3, phase: 'painting', skippable: false, threshold: null },
@@ -212,6 +212,38 @@ export const BUILTIN_MODEL_TYPES = [
       { id: 's5', name: 'Layer',     points: 3, phase: 'painting', skippable: true,  threshold: null },
       { id: 's6', name: 'Highlight', points: 4, phase: 'painting', skippable: true,  threshold: 'painted' },
       { id: 's7', name: 'Basing',    points: 2, phase: 'basing',   skippable: true,  threshold: 'finished' },
+    ]
+  },
+  {
+    id: 'large_skimmer',
+    name: 'Large Skimmer',
+    builtIn: true,
+    // Double the surface area of a Light Skimmer, mirroring the Light/Large/
+    // Super-Heavy split used for tracked Vehicles.
+    stages: [
+      { id: 's1', name: 'Assembly',  points: 12, phase: 'assembly', skippable: false, threshold: 'table_ready' },
+      { id: 's2', name: 'Prime',     points: 6,  phase: 'painting', skippable: false, threshold: null },
+      { id: 's3', name: 'Basecoat',  points: 10, phase: 'painting', skippable: false, threshold: null },
+      { id: 's4', name: 'Shade',     points: 4,  phase: 'painting', skippable: false, threshold: null },
+      { id: 's5', name: 'Layer',     points: 6,  phase: 'painting', skippable: true,  threshold: null },
+      { id: 's6', name: 'Highlight', points: 8,  phase: 'painting', skippable: true,  threshold: 'painted' },
+      { id: 's7', name: 'Basing',    points: 4,  phase: 'basing',   skippable: true,  threshold: 'finished' },
+    ]
+  },
+  {
+    id: 'super_heavy_skimmer',
+    name: 'Super-Heavy Skimmer',
+    builtIn: true,
+    // Superheavy flyers/grav-tanks (e.g. Tau Manta) — triple a Light
+    // Skimmer's stage points (25 → 75).
+    stages: [
+      { id: 's1', name: 'Assembly',  points: 18, phase: 'assembly', skippable: false, threshold: 'table_ready' },
+      { id: 's2', name: 'Prime',     points: 9,  phase: 'painting', skippable: false, threshold: null },
+      { id: 's3', name: 'Basecoat',  points: 15, phase: 'painting', skippable: false, threshold: null },
+      { id: 's4', name: 'Shade',     points: 6,  phase: 'painting', skippable: false, threshold: null },
+      { id: 's5', name: 'Layer',     points: 9,  phase: 'painting', skippable: true,  threshold: null },
+      { id: 's6', name: 'Highlight', points: 12, phase: 'painting', skippable: true,  threshold: 'painted' },
+      { id: 's7', name: 'Basing',    points: 6,  phase: 'basing',   skippable: true,  threshold: 'finished' },
     ]
   },
   {
@@ -370,7 +402,7 @@ export const TYPE_GROUPS = {
   'Mounted':        ['cavalry', 'monstrous_cavalry', 'jetbike', 'chariot'],
   'Large':          ['monster', 'walker', 'behemoth'],
   'Characters':     ['character', 'character_horse', 'character_monster'],
-  'Vehicles':       ['warmachine', 'vehicle', 'skimmer', 'large_vehicle', 'super_heavy_vehicle'],
+  'Vehicles':       ['warmachine', 'vehicle', 'skimmer', 'large_vehicle', 'super_heavy_vehicle', 'large_skimmer', 'super_heavy_skimmer'],
   'Special':        ['terrain'],
 };
 

--- a/js/data.js
+++ b/js/data.js
@@ -153,7 +153,7 @@ export const BUILTIN_MODEL_TYPES = [
   },
   {
     id: 'vehicle',
-    name: 'Vehicle',
+    name: 'Light Vehicle',
     builtIn: true,
     stages: [
       { id: 's1', name: 'Assembly',  points: 6, phase: 'assembly', skippable: false, threshold: 'table_ready' },
@@ -167,11 +167,10 @@ export const BUILTIN_MODEL_TYPES = [
   },
   {
     id: 'large_vehicle',
-    name: 'Large Vehicle / Super-Heavy',
+    name: 'Large Vehicle',
     builtIn: true,
-    // Super-heavy tanks, titans, and gargants — double the surface area of a
-    // standard Vehicle, so stage points scale up proportionally rather than
-    // just being an arbitrary round number.
+    // Double the surface area of a Light Vehicle — stage points scale up
+    // proportionally rather than being an arbitrary round number.
     stages: [
       { id: 's1', name: 'Assembly',  points: 12, phase: 'assembly', skippable: false, threshold: 'table_ready' },
       { id: 's2', name: 'Prime',     points: 6,  phase: 'painting', skippable: false, threshold: null },
@@ -180,6 +179,22 @@ export const BUILTIN_MODEL_TYPES = [
       { id: 's5', name: 'Layer',     points: 6,  phase: 'painting', skippable: true,  threshold: null },
       { id: 's6', name: 'Highlight', points: 8,  phase: 'painting', skippable: true,  threshold: 'painted' },
       { id: 's7', name: 'Basing',    points: 4,  phase: 'basing',   skippable: true,  threshold: 'finished' },
+    ]
+  },
+  {
+    id: 'super_heavy_vehicle',
+    name: 'Super-Heavy Vehicle',
+    builtIn: true,
+    // Baneblade-chassis tanks, gargants, and titans — triple a Light
+    // Vehicle's stage points (25 → 75).
+    stages: [
+      { id: 's1', name: 'Assembly',  points: 18, phase: 'assembly', skippable: false, threshold: 'table_ready' },
+      { id: 's2', name: 'Prime',     points: 9,  phase: 'painting', skippable: false, threshold: null },
+      { id: 's3', name: 'Basecoat',  points: 15, phase: 'painting', skippable: false, threshold: null },
+      { id: 's4', name: 'Shade',     points: 6,  phase: 'painting', skippable: false, threshold: null },
+      { id: 's5', name: 'Layer',     points: 9,  phase: 'painting', skippable: true,  threshold: null },
+      { id: 's6', name: 'Highlight', points: 12, phase: 'painting', skippable: true,  threshold: 'painted' },
+      { id: 's7', name: 'Basing',    points: 6,  phase: 'basing',   skippable: true,  threshold: 'finished' },
     ]
   },
   {
@@ -355,7 +370,7 @@ export const TYPE_GROUPS = {
   'Mounted':        ['cavalry', 'monstrous_cavalry', 'jetbike', 'chariot'],
   'Large':          ['monster', 'walker', 'behemoth'],
   'Characters':     ['character', 'character_horse', 'character_monster'],
-  'Vehicles':       ['warmachine', 'vehicle', 'skimmer', 'large_vehicle'],
+  'Vehicles':       ['warmachine', 'vehicle', 'skimmer', 'large_vehicle', 'super_heavy_vehicle'],
   'Special':        ['terrain'],
 };
 

--- a/js/data.js
+++ b/js/data.js
@@ -155,14 +155,16 @@ export const BUILTIN_MODEL_TYPES = [
     id: 'vehicle',
     name: 'Light Vehicle',
     builtIn: true,
+    // No Basing stage — tanks and skimmers sit on the table (or a flight
+    // stand) rather than a scenic base, so Highlight is the final stage and
+    // carries the 'finished' threshold directly.
     stages: [
       { id: 's1', name: 'Assembly',  points: 6, phase: 'assembly', skippable: false, threshold: 'table_ready' },
       { id: 's2', name: 'Prime',     points: 3, phase: 'painting', skippable: false, threshold: null },
       { id: 's3', name: 'Basecoat',  points: 5, phase: 'painting', skippable: false, threshold: null },
       { id: 's4', name: 'Shade',     points: 2, phase: 'painting', skippable: false, threshold: null },
       { id: 's5', name: 'Layer',     points: 3, phase: 'painting', skippable: true,  threshold: null },
-      { id: 's6', name: 'Highlight', points: 4, phase: 'painting', skippable: true,  threshold: 'painted' },
-      { id: 's7', name: 'Basing',    points: 2, phase: 'basing',   skippable: true,  threshold: 'finished' },
+      { id: 's6', name: 'Highlight', points: 6, phase: 'painting', skippable: true,  threshold: 'finished' },
     ]
   },
   {
@@ -170,15 +172,15 @@ export const BUILTIN_MODEL_TYPES = [
     name: 'Large Vehicle',
     builtIn: true,
     // Double the surface area of a Light Vehicle — stage points scale up
-    // proportionally rather than being an arbitrary round number.
+    // proportionally rather than being an arbitrary round number. No Basing
+    // stage — see Light Vehicle.
     stages: [
       { id: 's1', name: 'Assembly',  points: 12, phase: 'assembly', skippable: false, threshold: 'table_ready' },
       { id: 's2', name: 'Prime',     points: 6,  phase: 'painting', skippable: false, threshold: null },
       { id: 's3', name: 'Basecoat',  points: 10, phase: 'painting', skippable: false, threshold: null },
       { id: 's4', name: 'Shade',     points: 4,  phase: 'painting', skippable: false, threshold: null },
       { id: 's5', name: 'Layer',     points: 6,  phase: 'painting', skippable: true,  threshold: null },
-      { id: 's6', name: 'Highlight', points: 8,  phase: 'painting', skippable: true,  threshold: 'painted' },
-      { id: 's7', name: 'Basing',    points: 4,  phase: 'basing',   skippable: true,  threshold: 'finished' },
+      { id: 's6', name: 'Highlight', points: 12, phase: 'painting', skippable: true,  threshold: 'finished' },
     ]
   },
   {
@@ -186,15 +188,14 @@ export const BUILTIN_MODEL_TYPES = [
     name: 'Super-Heavy Vehicle',
     builtIn: true,
     // Baneblade-chassis tanks, gargants, and titans — triple a Light
-    // Vehicle's stage points (25 → 75).
+    // Vehicle's stage points (25 → 75). No Basing stage — see Light Vehicle.
     stages: [
       { id: 's1', name: 'Assembly',  points: 18, phase: 'assembly', skippable: false, threshold: 'table_ready' },
       { id: 's2', name: 'Prime',     points: 9,  phase: 'painting', skippable: false, threshold: null },
       { id: 's3', name: 'Basecoat',  points: 15, phase: 'painting', skippable: false, threshold: null },
       { id: 's4', name: 'Shade',     points: 6,  phase: 'painting', skippable: false, threshold: null },
       { id: 's5', name: 'Layer',     points: 9,  phase: 'painting', skippable: true,  threshold: null },
-      { id: 's6', name: 'Highlight', points: 12, phase: 'painting', skippable: true,  threshold: 'painted' },
-      { id: 's7', name: 'Basing',    points: 6,  phase: 'basing',   skippable: true,  threshold: 'finished' },
+      { id: 's6', name: 'Highlight', points: 18, phase: 'painting', skippable: true,  threshold: 'finished' },
     ]
   },
   {
@@ -203,15 +204,15 @@ export const BUILTIN_MODEL_TYPES = [
     builtIn: true,
     // Functionally identical to Light Vehicle — same painting workload —
     // this is purely a distinct type so anti-grav vehicles get the skimmer
-    // icon instead of the tracked-tank icon in the pile pictogram.
+    // icon instead of the tracked-tank icon in the pile pictogram. No Basing
+    // stage — skimmers mount on a flight stand instead of a scenic base.
     stages: [
       { id: 's1', name: 'Assembly',  points: 6, phase: 'assembly', skippable: false, threshold: 'table_ready' },
       { id: 's2', name: 'Prime',     points: 3, phase: 'painting', skippable: false, threshold: null },
       { id: 's3', name: 'Basecoat',  points: 5, phase: 'painting', skippable: false, threshold: null },
       { id: 's4', name: 'Shade',     points: 2, phase: 'painting', skippable: false, threshold: null },
       { id: 's5', name: 'Layer',     points: 3, phase: 'painting', skippable: true,  threshold: null },
-      { id: 's6', name: 'Highlight', points: 4, phase: 'painting', skippable: true,  threshold: 'painted' },
-      { id: 's7', name: 'Basing',    points: 2, phase: 'basing',   skippable: true,  threshold: 'finished' },
+      { id: 's6', name: 'Highlight', points: 6, phase: 'painting', skippable: true,  threshold: 'finished' },
     ]
   },
   {
@@ -219,15 +220,15 @@ export const BUILTIN_MODEL_TYPES = [
     name: 'Large Skimmer',
     builtIn: true,
     // Double the surface area of a Light Skimmer, mirroring the Light/Large/
-    // Super-Heavy split used for tracked Vehicles.
+    // Super-Heavy split used for tracked Vehicles. No Basing stage — see
+    // Light Skimmer.
     stages: [
       { id: 's1', name: 'Assembly',  points: 12, phase: 'assembly', skippable: false, threshold: 'table_ready' },
       { id: 's2', name: 'Prime',     points: 6,  phase: 'painting', skippable: false, threshold: null },
       { id: 's3', name: 'Basecoat',  points: 10, phase: 'painting', skippable: false, threshold: null },
       { id: 's4', name: 'Shade',     points: 4,  phase: 'painting', skippable: false, threshold: null },
       { id: 's5', name: 'Layer',     points: 6,  phase: 'painting', skippable: true,  threshold: null },
-      { id: 's6', name: 'Highlight', points: 8,  phase: 'painting', skippable: true,  threshold: 'painted' },
-      { id: 's7', name: 'Basing',    points: 4,  phase: 'basing',   skippable: true,  threshold: 'finished' },
+      { id: 's6', name: 'Highlight', points: 12, phase: 'painting', skippable: true,  threshold: 'finished' },
     ]
   },
   {
@@ -235,15 +236,14 @@ export const BUILTIN_MODEL_TYPES = [
     name: 'Super-Heavy Skimmer',
     builtIn: true,
     // Superheavy flyers/grav-tanks (e.g. Tau Manta) — triple a Light
-    // Skimmer's stage points (25 → 75).
+    // Skimmer's stage points (25 → 75). No Basing stage — see Light Skimmer.
     stages: [
       { id: 's1', name: 'Assembly',  points: 18, phase: 'assembly', skippable: false, threshold: 'table_ready' },
       { id: 's2', name: 'Prime',     points: 9,  phase: 'painting', skippable: false, threshold: null },
       { id: 's3', name: 'Basecoat',  points: 15, phase: 'painting', skippable: false, threshold: null },
       { id: 's4', name: 'Shade',     points: 6,  phase: 'painting', skippable: false, threshold: null },
       { id: 's5', name: 'Layer',     points: 9,  phase: 'painting', skippable: true,  threshold: null },
-      { id: 's6', name: 'Highlight', points: 12, phase: 'painting', skippable: true,  threshold: 'painted' },
-      { id: 's7', name: 'Basing',    points: 6,  phase: 'basing',   skippable: true,  threshold: 'finished' },
+      { id: 's6', name: 'Highlight', points: 18, phase: 'painting', skippable: true,  threshold: 'finished' },
     ]
   },
   {

--- a/js/import.js
+++ b/js/import.js
@@ -35,6 +35,9 @@ const TYPE_LABELS = {
   vehicle: 'Light Vehicle',
   large_vehicle: 'Large Vehicle',
   super_heavy_vehicle: 'Super-Heavy Vehicle',
+  skimmer: 'Light Skimmer',
+  large_skimmer: 'Large Skimmer',
+  super_heavy_skimmer: 'Super-Heavy Skimmer',
   walker: 'Walker',
 };
 

--- a/js/import.js
+++ b/js/import.js
@@ -32,8 +32,9 @@ const TYPE_LABELS = {
   warmachine: 'War Machine',
   chariot: 'Chariot',
   swarm: 'Swarm',
-  vehicle: 'Vehicle',
+  vehicle: 'Light Vehicle',
   large_vehicle: 'Large Vehicle',
+  super_heavy_vehicle: 'Super-Heavy Vehicle',
   walker: 'Walker',
 };
 

--- a/js/import.js
+++ b/js/import.js
@@ -33,6 +33,7 @@ const TYPE_LABELS = {
   chariot: 'Chariot',
   swarm: 'Swarm',
   vehicle: 'Vehicle',
+  large_vehicle: 'Large Vehicle',
   walker: 'Walker',
 };
 

--- a/js/w40k-import.js
+++ b/js/w40k-import.js
@@ -8,6 +8,8 @@ function detectModelType(name, section) {
 
   if (/swarm|rippers?/.test(n)) return 'swarm';
 
+  if (/baneblade|banehammer|banesword|doomhammer|hellhammer|shadowsword|stormlord|stormsword|fellblade|typhon|falchion|mastodon|gorgon|thunderhawk|stormsurge|ta'?unar|stompa|gargant|great gargant|mega.?dread|lord of skulls|brass scorpion|warhound|reaver titan|warlord titan/.test(n)) return 'large_vehicle';
+
   if (/dreadnought|sentinel|armiger|knight|titan|killa kan|deff dread|gorkanaut|morkanaut/.test(n)) return 'walker';
 
   if (/rhino|predator|land raider|repulsor|gladiator|impulsor|vindicator|razorback|chimera|hellhound|leman russ|basilisk|manticore|deathstrike|wave serpent|falcon|hammerhead|devilfish|broadside|ghostkeel|defiler|forgefiend|maulerfiend|skorpius|dunecrawler/.test(n)) return 'vehicle';

--- a/js/w40k-import.js
+++ b/js/w40k-import.js
@@ -8,7 +8,7 @@ function detectModelType(name, section) {
 
   if (/swarm|rippers?/.test(n)) return 'swarm';
 
-  if (/baneblade|banehammer|banesword|doomhammer|hellhammer|shadowsword|stormlord|stormsword|fellblade|typhon|falchion|mastodon|gorgon|thunderhawk|stormsurge|ta'?unar|stompa|gargant|great gargant|mega.?dread|lord of skulls|brass scorpion|warhound|reaver titan|warlord titan/.test(n)) return 'large_vehicle';
+  if (/baneblade|banehammer|banesword|doomhammer|hellhammer|shadowsword|stormlord|stormsword|fellblade|typhon|falchion|mastodon|gorgon|thunderhawk|stormsurge|ta'?unar|stompa|gargant|great gargant|mega.?dread|lord of skulls|brass scorpion|warhound|reaver titan|warlord titan/.test(n)) return 'super_heavy_vehicle';
 
   if (/dreadnought|sentinel|armiger|knight|titan|killa kan|deff dread|gorkanaut|morkanaut/.test(n)) return 'walker';
 

--- a/js/w40k-import.js
+++ b/js/w40k-import.js
@@ -14,6 +14,9 @@ function detectModelType(name, section) {
 
   if (/rhino|predator|land raider|repulsor|gladiator|impulsor|vindicator|razorback|chimera|hellhound|leman russ|basilisk|manticore|deathstrike|wave serpent|falcon|hammerhead|devilfish|broadside|ghostkeel|defiler|forgefiend|maulerfiend|skorpius|dunecrawler/.test(n)) return 'vehicle';
 
+  // Superheavy flyers/grav-tanks, checked before the regular skimmer list.
+  if (/\bmanta\b/.test(n)) return 'super_heavy_skimmer';
+
   // Anti-grav skimmers (checked after the tracked-vehicle list above so
   // "Land Raider" still matches that list's own "land raider" entry first).
   if (/\braider\b|\bravager\b|venom|razorwing|voidraven|tantalus/.test(n)) return 'skimmer';


### PR DESCRIPTION
Standard Vehicle stages doubled across the board so a super-heavy
tank/titan-scale model scores proportionally to a regular Vehicle
(25 pts) rather than an arbitrary number. Wired into the Vehicles
type group, dashboard pictogram icon, and the 40K list-import
auto-detection heuristic for named super-heavies.