### PR TITLE
Fix cavalry pictogram sitting lower than other pile figures

### DIFF
--- a/index.html
+++ b/index.html
@@ -2035,17 +2035,22 @@
     <path d="M23 6 L28.5 1.6 L30 2.6 L25.2 7 Z"></path>
   </symbol>
   <symbol id="miniCavalry" viewBox="0 0 34 28">
-    <path d="M6 15.5 L2 15 L3.5 19.5 L7 17.5 Z"></path>
-    <ellipse cx="14" cy="18" rx="9" ry="4.3"></ellipse>
-    <path d="M19 17 L22.5 10.7 L25.5 11.2 L22.5 17.5 Z"></path>
-    <ellipse cx="27" cy="10" rx="5" ry="2.6" transform="rotate(-25 27 10)"></ellipse>
-    <path d="M23 8.3 L22.2 5.2 L24.6 7.8 Z"></path>
-    <circle cx="14.5" cy="8.7" r="2.4"></circle>
-    <rect x="12.5" y="11" width="4" height="7" rx="1.3"></rect>
-    <rect x="8" y="20" width="1.9" height="7"></rect>
-    <rect x="11" y="20" width="1.9" height="7"></rect>
-    <rect x="19" y="20" width="1.9" height="7"></rect>
-    <rect x="22" y="20" width="1.9" height="7"></rect>
+    <!-- Shifted up from the raw art's baseline so the hooves leave the same
+         ground-margin below them as miniFig/miniTank, instead of running
+         almost flush to the viewBox edge and reading as "sitting lower". -->
+    <g transform="translate(0,-1.3)">
+      <path d="M6 15.5 L2 15 L3.5 19.5 L7 17.5 Z"></path>
+      <ellipse cx="14" cy="18" rx="9" ry="4.3"></ellipse>
+      <path d="M19 17 L22.5 10.7 L25.5 11.2 L22.5 17.5 Z"></path>
+      <ellipse cx="27" cy="10" rx="5" ry="2.6" transform="rotate(-25 27 10)"></ellipse>
+      <path d="M23 8.3 L22.2 5.2 L24.6 7.8 Z"></path>
+      <circle cx="14.5" cy="8.7" r="2.4"></circle>
+      <rect x="12.5" y="11" width="4" height="7" rx="1.3"></rect>
+      <rect x="8" y="20" width="1.9" height="7"></rect>
+      <rect x="11" y="20" width="1.9" height="7"></rect>
+      <rect x="19" y="20" width="1.9" height="7"></rect>
+      <rect x="22" y="20" width="1.9" height="7"></rect>
+    </g>
   </symbol>
   <symbol id="miniWalker" viewBox="0 0 26 28">
     <rect x="10.5" y="2" width="5" height="3.2" rx="0.9"></rect>


### PR DESCRIPTION
The miniCavalry symbol's hooves ran almost flush to the viewBox's bottom
edge, unlike miniFig/miniTank which leave a small ground margin below
their lowest ink. Since the pile's flex layout bottom-aligns each
figure's box, this made cavalry visibly sit lower than its neighbors.
Shift the artwork up within its viewBox to match the others' margin.