### PR TITLE
Give mounted characters the cavalry pictogram in the pile

### DIFF
--- a/js/dashboard.js
+++ b/js/dashboard.js
@@ -523,6 +523,7 @@ const ICON_CONFIG = {
   large_skimmer:       { symbol: 'miniSkimmer', aspect: 15 / 34, mult: 1.9  },
   super_heavy_skimmer: { symbol: 'miniSkimmer', aspect: 15 / 34, mult: 2.4  },
   cavalry:             { symbol: 'miniCavalry', aspect: 28 / 34, mult: 1.15 },
+  character_horse:     { symbol: 'miniCavalry', aspect: 28 / 34, mult: 1.15 },
   walker:              { symbol: 'miniWalker',  aspect: 28 / 26, mult: 1.2  },
 };
 


### PR DESCRIPTION
character_horse models had no ICON_CONFIG entry, so they fell back to
the generic standing-figure silhouette instead of the horse shape
already used for regular cavalry.