### PR TITLE
Add dedicated jetbike silhouette to pile pictogram

### DIFF
--- a/index.html
+++ b/index.html
@@ -2062,6 +2062,17 @@
     <rect x="4.5" y="25" width="8" height="2.6" rx="0.8"></rect>
     <rect x="13.5" y="25" width="8" height="2.6" rx="0.8"></rect>
   </symbol>
+  <symbol id="miniJetbike" viewBox="0 0 34 28">
+    <!-- Hover-bike hull (skimmer-style prone body) with a nose fin and a
+         rider crouched forward over the handlebars, distinguishing it from
+         both the seated miniCavalry mount and the riderless miniSkimmer. -->
+    <ellipse cx="17" cy="24.5" rx="11" ry="1"></ellipse>
+    <path d="M3 20 L7.5 17 H26.5 L32 20 L26.5 23 H7.5 Z"></path>
+    <path d="M25 17 L30.5 10.5 L32 11.6 L27.2 18 Z"></path>
+    <path d="M16.5 12.8 L21 16.4 L20 17.7 L15.6 14.2 Z"></path>
+    <circle cx="14" cy="9.3" r="2.6"></circle>
+    <path d="M11.2 17.3 C11.2 13.2 12.4 10.7 14 10.5 C15.9 10.5 17.6 12.7 18.4 15.6 L19.4 17.5 Z"></path>
+  </symbol>
 </svg>
 <div id="app">
 

--- a/index.html
+++ b/index.html
@@ -2032,7 +2032,7 @@
   <symbol id="miniSkimmer" viewBox="0 0 34 15">
     <ellipse cx="17" cy="13.6" rx="11" ry="1"></ellipse>
     <path d="M2 9 L6.5 6 H25.5 L31.5 9 L25.5 12 H6.5 Z"></path>
-    <path d="M23 6 L28.5 1.6 L30 2.6 L25.2 7 Z"></path>
+    <path d="M29.3 8 L22.3 1.6 L21 1 L27.8 6.9 Z"></path>
   </symbol>
   <symbol id="miniCavalry" viewBox="0 0 34 28">
     <!-- Shifted up from the raw art's baseline so the hooves leave the same

--- a/index.html
+++ b/index.html
@@ -2068,7 +2068,7 @@
          both the seated miniCavalry mount and the riderless miniSkimmer. -->
     <ellipse cx="17" cy="24.5" rx="11" ry="1"></ellipse>
     <path d="M3 20 L7.5 17 H26.5 L32 20 L26.5 23 H7.5 Z"></path>
-    <path d="M25 17 L30.5 10.5 L32 11.6 L27.2 18 Z"></path>
+    <path d="M28.5 18.3 L21 9 L22.3 8.2 L29.7 17.2 Z"></path>
     <path d="M16.5 12.8 L21 16.4 L20 17.7 L15.6 14.2 Z"></path>
     <circle cx="14" cy="9.3" r="2.6"></circle>
     <path d="M11.2 17.3 C11.2 13.2 12.4 10.7 14 10.5 C15.9 10.5 17.6 12.7 18.4 15.6 L19.4 17.5 Z"></path>

--- a/js/dashboard.js
+++ b/js/dashboard.js
@@ -524,6 +524,7 @@ const ICON_CONFIG = {
   super_heavy_skimmer: { symbol: 'miniSkimmer', aspect: 15 / 34, mult: 2.4  },
   cavalry:             { symbol: 'miniCavalry', aspect: 28 / 34, mult: 1.15 },
   character_horse:     { symbol: 'miniCavalry', aspect: 28 / 34, mult: 1.15 },
+  jetbike:             { symbol: 'miniJetbike', aspect: 28 / 34, mult: 1.3  },
   walker:              { symbol: 'miniWalker',  aspect: 28 / 26, mult: 1.2  },
 };
 


### PR DESCRIPTION
Jetbike-type models previously fell back to the generic standing-figure
icon in the pile of potential/painted pictograms. Add a miniJetbike SVG
symbol (hover-bike hull with a prone rider and forward fin) and wire it
into ICON_CONFIG so jetbike models render as a bike rather than a person.