### PR TITLE
Add Roadmap tab and backlog separation to Model Pool

### DIFF
--- a/index.html
+++ b/index.html
@@ -1843,6 +1843,30 @@
     .folder-empty { font-size: 0.85em; color: var(--text-muted); font-style: italic; padding: 0.25em 0; }
     .folder-unfiled .folder-header { background: var(--bg2); }
 
+    /* Roadmap group / backlog wrapper (reuse folder-section chrome) */
+    .pool-section-label { font-size: 0.78em; font-weight: 600; text-transform: uppercase; letter-spacing: 0.04em; color: var(--text-muted); margin: 0.2em 0 0.5em; }
+    .folder-section.roadmap-group { border-color: var(--accent); }
+    .folder-section.backlog-section { margin-top: 1em; }
+
+    /* ================================================================
+       ROADMAP TAB
+    ================================================================ */
+    .roadmap-intro { color: var(--text-muted); font-size: 0.88em; margin: -0.3em 0 1.25em; }
+    .roadmap-campaigns { display: flex; flex-direction: column; gap: 0.75em; margin-bottom: 1.5em; }
+    .roadmap-campaign-card { background: var(--surface); border: 1px solid var(--border); border-radius: var(--radius); padding: 0.9em 1em; }
+    .roadmap-campaign-header { display: flex; align-items: center; gap: 0.6em; flex-wrap: wrap; margin-bottom: 0.5em; }
+    .roadmap-campaign-name { font-family: var(--font-display); font-weight: 600; font-size: 1em; }
+    .roadmap-deadline { font-size: 0.8em; color: var(--text-muted); margin-left: auto; }
+    .roadmap-campaign-actions { display: flex; align-items: center; gap: 0.5em; margin-top: 0.6em; flex-wrap: wrap; }
+    .roadmap-move-btns { display: flex; gap: 0.2em; }
+    .roadmap-move-btns .btn:disabled { opacity: 0.3; cursor: not-allowed; }
+    .roadmap-add-section { margin-top: 1em; }
+    .roadmap-add-section h3 { font-family: var(--font-display); font-size: 1em; margin-bottom: 0.6em; }
+    .roadmap-available-list { display: flex; flex-direction: column; gap: 0.4em; }
+    .roadmap-available-row { display: flex; align-items: center; gap: 0.6em; background: var(--surface); border: 1px solid var(--border); border-radius: var(--radius); padding: 0.5em 0.75em; flex-wrap: wrap; }
+    .roadmap-available-name { font-weight: 600; }
+    .roadmap-available-count { font-size: 0.8em; color: var(--text-muted); margin-left: auto; }
+
     /* ================================================================
        POOL SELECT MODE / MASS MOVE
     ================================================================ */
@@ -2118,6 +2142,10 @@
       <span class="tab-icon">🛡️</span>
       <span class="tab-label">Armies</span>
     </button>
+    <button class="nav-tab" data-tab="roadmap" role="tab">
+      <span class="tab-icon">🗺️</span>
+      <span class="tab-label">Roadmap</span>
+    </button>
     <button class="nav-tab" data-tab="queues" role="tab">
       <span class="tab-icon">📋</span>
       <span class="tab-label">Queue</span>
@@ -2153,6 +2181,11 @@
       <div id="collectionsView"></div>
     </div>
 
+    <!-- Roadmap -->
+    <div class="tab-panel" id="tab-roadmap">
+      <div id="roadmapView"></div>
+    </div>
+
     <!-- Queues -->
     <div class="tab-panel" id="tab-queues">
       <div id="queuesView"></div>
@@ -2175,6 +2208,7 @@
   import { isConfigured, isConnected, wasConnected, getSavedEmail, getLastSyncTime, init as gDriveInit, connect as gDriveConnect, disconnect as gDriveDisconnect, loadFromDrive, saveToDrive } from './js/gdrive.js';
   import { renderModelPool, showModelForm, showModelTypeEditor } from './js/models.js';
   import { renderCollections } from './js/collections.js';
+  import { renderRoadmap } from './js/roadmap.js';
   import { renderDashboard } from './js/dashboard.js';
   import { renderQueues } from './js/queue.js';
   import { renderActivity } from './js/activity.js';
@@ -2212,6 +2246,7 @@
     if (tabId === 'dashboard') renderDashboard();
     if (tabId === 'pool') renderModelPool();
     if (tabId === 'collections') renderCollections();
+    if (tabId === 'roadmap') renderRoadmap();
     if (tabId === 'queues') renderQueues();
     if (tabId === 'activity') renderActivity();
   }

--- a/js/collections.js
+++ b/js/collections.js
@@ -4,7 +4,8 @@ import {
   appData, createCollection, deleteCollection,
   createList, deleteList, addModelToList, removeModelFromList,
   setModelSplits, removeModelSplits, splitModelPoints, splitModelThreshold,
-  listStats, saveData, uid, GAME_SYSTEMS, modelPoints, modelThreshold
+  listStats, saveData, uid, GAME_SYSTEMS, modelPoints, modelThreshold,
+  addListToRoadmap, removeListFromRoadmap
 } from './data.js';
 import { showModal, closeModal, showConfirm, toast, progressBar, thresholdBadge, createDateInput, getDateValue, formatDate } from './ui.js';
 import { applyTheme, resetTheme, setCurrentSystem, resetCurrentSystem, getTerm } from './theme.js';
@@ -158,7 +159,7 @@ function renderCollectionsSidebar() {
   });
 }
 
-function selectCollection(colId) {
+export function selectCollection(colId) {
   activeCollectionId = colId;
   activeListId = null;
   const col = appData.collections[colId];
@@ -206,7 +207,7 @@ function selectCollection(colId) {
   main.querySelector('#deleteCollBtn')?.addEventListener('click', () => confirmDeleteCollection(colId));
 }
 
-function selectList(listId) {
+export function selectList(listId) {
   activeListId = listId;
   const list = appData.lists[listId];
   if (!list) return;
@@ -221,6 +222,7 @@ function selectList(listId) {
       <button class="btn btn-sm" id="backToCol">← ${col?.name || 'Back'}</button>
       <h2>${list.name}</h2>
       <div style="margin-left:auto;display:flex;gap:0.4em">
+        <button class="btn btn-sm ${list.onRoadmap ? 'btn-primary' : ''}" id="toggleRoadmapBtn" title="${list.onRoadmap ? 'On the roadmap — click to move back to backlog' : 'Add to roadmap as active work'}">🗺️ ${list.onRoadmap ? 'On Roadmap' : 'Add to Roadmap'}</button>
         <button class="btn btn-sm" id="shareListBtn" title="Share progress">📤 Share</button>
         <button class="btn btn-sm btn-danger" id="deleteListBtn" title="Delete army list">🗑️ Delete</button>
       </div>
@@ -258,6 +260,16 @@ function selectList(listId) {
   main.querySelector('#addModelToListBtn')?.addEventListener('click', () => showAddModelToList(listId));
   main.querySelector('#shareListBtn')?.addEventListener('click', () => shareList(listId));
   main.querySelector('#deleteListBtn')?.addEventListener('click', () => confirmDeleteList(listId));
+  main.querySelector('#toggleRoadmapBtn')?.addEventListener('click', () => {
+    if (list.onRoadmap) {
+      removeListFromRoadmap(listId);
+      toast('Moved back to backlog', 'info');
+    } else {
+      addListToRoadmap(listId);
+      toast('Added to roadmap!', 'success');
+    }
+    selectList(listId);
+  });
   const deadlineEl = document.getElementById('listDeadlineInput');
   const saveListDeadline = () => {
     const val = getDateValue('listDeadlineInput');

--- a/js/data.js
+++ b/js/data.js
@@ -896,7 +896,7 @@ export function deleteCollection(id) {
 
 export function createList({ name, collectionId }) {
   const id = uid();
-  appData.lists[id] = { id, name, collectionId, modelIds: [] };
+  appData.lists[id] = { id, name, collectionId, modelIds: [], onRoadmap: false, roadmapOrder: 0 };
   const col = appData.collections[collectionId];
   if (col) col.listIds.push(id);
   saveData();
@@ -991,6 +991,47 @@ export function splitModelThreshold(model, splitSize, offset) {
     if (allDone) return thresh;
   }
   return hasAnyProgress ? null : 'not_started';
+}
+
+// --- Roadmap helpers ---
+// A List "on the roadmap" is treated as active/current work; everything else
+// (including all models not attached to a roadmap list) is backlog/future work.
+
+export function getRoadmapLists() {
+  return Object.values(appData.lists)
+    .filter(l => l.onRoadmap)
+    .sort((a, b) => (a.roadmapOrder || 0) - (b.roadmapOrder || 0));
+}
+
+export function addListToRoadmap(listId) {
+  const list = appData.lists[listId];
+  if (!list || list.onRoadmap) return;
+  const maxOrder = getRoadmapLists().reduce((max, l) => Math.max(max, l.roadmapOrder || 0), 0);
+  list.onRoadmap = true;
+  list.roadmapOrder = maxOrder + 1;
+  saveData();
+}
+
+export function removeListFromRoadmap(listId) {
+  const list = appData.lists[listId];
+  if (!list) return;
+  list.onRoadmap = false;
+  saveData();
+}
+
+export function moveRoadmapList(listId, direction) {
+  const ordered = getRoadmapLists();
+  const idx = ordered.findIndex(l => l.id === listId);
+  if (idx === -1) return;
+  const newIdx = direction === 'up' ? idx - 1 : idx + 1;
+  if (newIdx < 0 || newIdx >= ordered.length) return;
+  const a = ordered[idx], b = ordered[newIdx];
+  [a.roadmapOrder, b.roadmapOrder] = [b.roadmapOrder, a.roadmapOrder];
+  saveData();
+}
+
+export function isModelOnRoadmap(modelId) {
+  return getRoadmapLists().some(l => (l.modelIds || []).includes(modelId));
 }
 
 // --- Session helpers ---

--- a/js/models.js
+++ b/js/models.js
@@ -5,7 +5,7 @@ import {
   logProgress, logSession, modelPoints, modelThreshold, stageCap, uid, saveData,
   getAllModelTypes, saveCustomModelType, deleteCustomModelType,
   saveModelTypeOverride, resetModelTypeOverride, BUILTIN_MODEL_TYPES, TYPE_GROUPS,
-  createFolder, updateFolder, deleteFolder, getAllFolders
+  createFolder, updateFolder, deleteFolder, getAllFolders, getRoadmapLists
 } from './data.js';
 import { showModal, closeModal, toast, progressBar, thresholdBadge, stageRow, today, createDateInput, getDateValue, createTimeInput } from './ui.js';
 import { getTerm } from './theme.js';
@@ -14,6 +14,10 @@ import { compressImageToBase64, IMAGE_SIZE_PRESETS } from './imageUtils.js';
 // Select mode state for mass move
 let _selectMode = false;
 let _selectedIds = new Set();
+
+// Backlog section collapse state — defaults to collapsed once the roadmap is
+// actually in use, so first-time users still see everything at a glance.
+let _backlogCollapsed = null;
 
 // Lazy import to avoid circular dependency
 async function pruneQueues() {
@@ -66,10 +70,17 @@ export function renderModelPool(containerId = 'modelPool') {
     return;
   }
 
-  // Group models by folder
+  const hasLists = Object.keys(appData.lists || {}).length > 0;
+  const roadmapLists = getRoadmapLists();
+  const roadmapModelIds = new Set();
+  roadmapLists.forEach(l => (l.modelIds || []).forEach(id => roadmapModelIds.add(id)));
+  const backlogModels = allModels.filter(m => !roadmapModelIds.has(m.id));
+
+  // Group backlog models by folder — roadmap models are pulled out into their
+  // own section above, regardless of which folder they happen to be filed in.
   const byFolder = {};
   const unfiled = [];
-  allModels.forEach(m => {
+  backlogModels.forEach(m => {
     if (m.folderId && appData.folders[m.folderId]) {
       if (!byFolder[m.folderId]) byFolder[m.folderId] = [];
       byFolder[m.folderId].push(m);
@@ -78,57 +89,105 @@ export function renderModelPool(containerId = 'modelPool') {
     }
   });
 
-  const hasLists = Object.keys(appData.lists || {}).length > 0;
   let html = '';
 
-  // Render each folder
-  folders.forEach(folder => {
-    const models = byFolder[folder.id] || [];
-    const collapsed = folder.collapsed;
-    html += `
-      <div class="folder-section" data-folder-id="${folder.id}">
-        <div class="folder-header">
-          <button class="folder-toggle" data-toggle-folder="${folder.id}">
-            <span class="folder-chevron">${collapsed ? '▶' : '▼'}</span>
-            <span class="folder-icon">📁</span>
-            <span class="folder-name">${folder.name}</span>
-            <span class="folder-count">${models.length}</span>
-          </button>
-          <div class="folder-actions">
-            <button class="btn btn-xs btn-primary" data-add-in-folder="${folder.id}">+</button>
-            <button class="btn btn-xs" data-rename-folder="${folder.id}">✏️</button>
-            <button class="btn btn-xs btn-danger" data-delete-folder="${folder.id}">🗑️</button>
+  // --- On the Roadmap ---
+  if (roadmapLists.length) {
+    const groups = roadmapLists.map(list => {
+      const models = (list.modelIds || []).map(id => appData.models[id]).filter(Boolean);
+      if (!models.length) return '';
+      return `
+        <div class="folder-section roadmap-group">
+          <div class="folder-header">
+            <div class="folder-toggle">
+              <span class="folder-icon">🗺️</span>
+              <span class="folder-name">${list.name}</span>
+              <span class="folder-count">${models.length}</span>
+            </div>
           </div>
-        </div>
-        ${collapsed ? '' : `
           <div class="folder-models">
-            ${models.length ? `<div class="model-grid">${models.map(modelCard).join('')}</div>` : `<p class="folder-empty">No models in this folder.</p>`}
-          </div>
-        `}
-      </div>
-    `;
-  });
-
-  // Unfiled models
-  if (unfiled.length > 0) {
-    html += `
-      <div class="folder-section folder-unfiled">
-        <div class="folder-header">
-          <div class="folder-toggle">
-            <span class="folder-icon">📂</span>
-            <span class="folder-name">Unfiled</span>
-            <span class="folder-count">${unfiled.length}</span>
+            <div class="model-grid">${models.map(modelCard).join('')}</div>
           </div>
         </div>
-        <div class="folder-models">
-          <div class="model-grid">${unfiled.map(modelCard).join('')}</div>
-        </div>
+      `;
+    }).join('');
+    if (groups) html += `<div class="pool-section-label">🗺️ On the Roadmap</div>${groups}`;
+  } else if (hasLists) {
+    html += `<div class="army-nudge roadmap-nudge">
+      <span class="army-nudge-icon">🗺️</span>
+      <div class="army-nudge-body">
+        <b>Nothing on the roadmap yet</b>
+        <span>Mark an army list active in the Roadmap tab to pull it out of the backlog and keep it top of mind.</span>
       </div>
-    `;
+      <button class="btn btn-sm btn-primary" id="nudgeRoadmapBtn">Roadmap →</button>
+    </div>`;
   }
 
-  if (!html) {
-    html = `<div class="empty-state"><p>No models yet. Use the + button to add one.</p></div>`;
+  // --- Backlog / Future Work (everything not on the roadmap) ---
+  // Until the user has manually toggled it, default to collapsed as soon as the
+  // roadmap has any active campaigns (recomputed live so it isn't stuck at
+  // whatever the roadmap looked like the first time a backlog existed).
+  const backlogCollapsed = _backlogCollapsed === null ? roadmapLists.length > 0 : _backlogCollapsed;
+
+  if (backlogModels.length > 0 || folders.length > 0) {
+    let backlogInner = '';
+    folders.forEach(folder => {
+      const models = byFolder[folder.id] || [];
+      const collapsed = folder.collapsed;
+      backlogInner += `
+        <div class="folder-section" data-folder-id="${folder.id}">
+          <div class="folder-header">
+            <button class="folder-toggle" data-toggle-folder="${folder.id}">
+              <span class="folder-chevron">${collapsed ? '▶' : '▼'}</span>
+              <span class="folder-icon">📁</span>
+              <span class="folder-name">${folder.name}</span>
+              <span class="folder-count">${models.length}</span>
+            </button>
+            <div class="folder-actions">
+              <button class="btn btn-xs btn-primary" data-add-in-folder="${folder.id}">+</button>
+              <button class="btn btn-xs" data-rename-folder="${folder.id}">✏️</button>
+              <button class="btn btn-xs btn-danger" data-delete-folder="${folder.id}">🗑️</button>
+            </div>
+          </div>
+          ${collapsed ? '' : `
+            <div class="folder-models">
+              ${models.length ? `<div class="model-grid">${models.map(modelCard).join('')}</div>` : `<p class="folder-empty">No models in this folder.</p>`}
+            </div>
+          `}
+        </div>
+      `;
+    });
+
+    if (unfiled.length > 0) {
+      backlogInner += `
+        <div class="folder-section folder-unfiled">
+          <div class="folder-header">
+            <div class="folder-toggle">
+              <span class="folder-icon">📂</span>
+              <span class="folder-name">Unfiled</span>
+              <span class="folder-count">${unfiled.length}</span>
+            </div>
+          </div>
+          <div class="folder-models">
+            <div class="model-grid">${unfiled.map(modelCard).join('')}</div>
+          </div>
+        </div>
+      `;
+    }
+
+    html += `
+      <div class="folder-section backlog-section">
+        <div class="folder-header">
+          <button class="folder-toggle" id="backlogToggle">
+            <span class="folder-chevron">${backlogCollapsed ? '▶' : '▼'}</span>
+            <span class="folder-icon">📦</span>
+            <span class="folder-name">Backlog / Future Work</span>
+            <span class="folder-count">${backlogModels.length}</span>
+          </button>
+        </div>
+        ${backlogCollapsed ? '' : `<div class="folder-models">${backlogInner}</div>`}
+      </div>
+    `;
   }
 
   if (!hasLists) {
@@ -173,6 +232,15 @@ export function renderModelPool(containerId = 'modelPool') {
 
   container.querySelector('#nudgeArmiesBtn')?.addEventListener('click', () => {
     document.querySelector('.nav-tab[data-tab="collections"]')?.click();
+  });
+
+  container.querySelector('#nudgeRoadmapBtn')?.addEventListener('click', () => {
+    document.querySelector('.nav-tab[data-tab="roadmap"]')?.click();
+  });
+
+  container.querySelector('#backlogToggle')?.addEventListener('click', () => {
+    _backlogCollapsed = !backlogCollapsed;
+    renderModelPool(containerId);
   });
 
   // Select mode controls

--- a/js/roadmap.js
+++ b/js/roadmap.js
@@ -1,0 +1,161 @@
+// roadmap.js — roadmap tab: pick which army lists are active "campaigns"
+// vs. everything else sitting quietly in the backlog
+
+import {
+  appData, GAME_SYSTEMS, listStats,
+  getRoadmapLists, addListToRoadmap, removeListFromRoadmap, moveRoadmapList
+} from './data.js';
+import { toast, progressBar, formatDate, daysUntil } from './ui.js';
+import { selectCollection, selectList } from './collections.js';
+
+export function renderRoadmap(containerId = 'roadmapView') {
+  const container = document.getElementById(containerId);
+  if (!container) return;
+
+  const allLists = Object.values(appData.lists);
+
+  if (!allLists.length) {
+    container.innerHTML = `
+      <div class="onboarding-card">
+        <div class="onboarding-title">🗺️ Roadmap</div>
+        <p class="onboarding-desc">The Roadmap is where you flag which army lists are active right now. Everything else settles quietly into the Model Pool's backlog, so it stops feeling overwhelming.</p>
+        <div class="onboarding-steps">
+          <div class="onboarding-step">
+            <span class="step-num">1</span>
+            <div>
+              <b>Create an Army List</b>
+              <p>Head to the Armies tab and set up a game system + list first.</p>
+            </div>
+          </div>
+          <div class="onboarding-step">
+            <span class="step-num">2</span>
+            <div>
+              <b>Add it to the Roadmap</b>
+              <p>Come back here and mark it active — its models pop out of the backlog on the Model Pool.</p>
+            </div>
+          </div>
+        </div>
+        <button class="btn btn-primary onboarding-cta" id="roadmapGoArmies">🛡️ Go to Armies</button>
+      </div>`;
+    container.querySelector('#roadmapGoArmies')?.addEventListener('click', () => {
+      document.querySelector('.nav-tab[data-tab="collections"]')?.click();
+    });
+    return;
+  }
+
+  const roadmapLists = getRoadmapLists();
+  const availableLists = allLists.filter(l => !l.onRoadmap);
+
+  container.innerHTML = `
+    <div class="panel-header">
+      <h2>🗺️ Roadmap</h2>
+    </div>
+    <p class="roadmap-intro">Campaigns below are your active, in-focus work. Everything else waits quietly in the Model Pool's Backlog section until you're ready for it.</p>
+    ${roadmapLists.length ? `
+      <div class="roadmap-campaigns">
+        ${roadmapLists.map((list, idx) => campaignCard(list, idx, roadmapLists.length)).join('')}
+      </div>
+    ` : `
+      <div class="empty-state">
+        <p>No campaigns on your roadmap yet.</p>
+        <p style="font-size:0.85em;color:var(--text-muted)">Add an army list below to mark it active.</p>
+      </div>
+    `}
+    <div class="roadmap-add-section">
+      <h3>Add to Roadmap</h3>
+      ${availableLists.length ? `
+        <div class="roadmap-available-list">
+          ${availableLists.map(availableListRow).join('')}
+        </div>
+      ` : `<p class="form-hint">All your army lists are already on the roadmap.</p>`}
+    </div>
+  `;
+
+  container.querySelectorAll('[data-roadmap-up]').forEach(btn => {
+    btn.addEventListener('click', () => {
+      moveRoadmapList(btn.dataset.roadmapUp, 'up');
+      renderRoadmap(containerId);
+    });
+  });
+  container.querySelectorAll('[data-roadmap-down]').forEach(btn => {
+    btn.addEventListener('click', () => {
+      moveRoadmapList(btn.dataset.roadmapDown, 'down');
+      renderRoadmap(containerId);
+    });
+  });
+  container.querySelectorAll('[data-roadmap-remove]').forEach(btn => {
+    btn.addEventListener('click', () => {
+      removeListFromRoadmap(btn.dataset.roadmapRemove);
+      toast('Moved back to backlog', 'info');
+      renderRoadmap(containerId);
+    });
+  });
+  container.querySelectorAll('[data-roadmap-add]').forEach(btn => {
+    btn.addEventListener('click', () => {
+      addListToRoadmap(btn.dataset.roadmapAdd);
+      toast('Added to roadmap!', 'success');
+      renderRoadmap(containerId);
+    });
+  });
+  container.querySelectorAll('[data-roadmap-open]').forEach(btn => {
+    btn.addEventListener('click', () => {
+      const list = appData.lists[btn.dataset.roadmapOpen];
+      if (!list) return;
+      document.querySelector('.nav-tab[data-tab="collections"]')?.click();
+      selectCollection(list.collectionId);
+      selectList(list.id);
+    });
+  });
+}
+
+function campaignCard(list, idx, total) {
+  const col = appData.collections[list.collectionId];
+  const sys = col ? GAME_SYSTEMS[col.gameSystemId] : null;
+  const stats = listStats(list);
+
+  let deadlineHtml = '';
+  if (list.deadline) {
+    const days = daysUntil(list.deadline);
+    const dateStr = formatDate(list.deadline, { day: 'numeric', month: 'short', year: 'numeric' });
+    const daysStr = days < 0 ? `${Math.abs(days)} days overdue` : days === 0 ? 'due today' : `${days} days to go`;
+    deadlineHtml = `<span class="roadmap-deadline">🎯 ${dateStr} · ${daysStr}</span>`;
+  }
+
+  return `
+    <div class="roadmap-campaign-card" data-list-id="${list.id}">
+      <div class="roadmap-campaign-header">
+        <span class="roadmap-campaign-name">${list.name}</span>
+        ${sys ? `<span class="sys-tag ${sys.theme}">${sys.shortLabel}</span>` : ''}
+        ${deadlineHtml}
+      </div>
+      ${progressBar(stats.pct)}
+      <div class="threshold-row">
+        <span class="thresh-item">⚔️ ${stats.tableReady}/${stats.total}</span>
+        <span class="thresh-item">🎨 ${stats.painted}/${stats.total}</span>
+        <span class="thresh-item">🏆 ${stats.finished}/${stats.total}</span>
+      </div>
+      <div class="roadmap-campaign-actions">
+        <div class="roadmap-move-btns">
+          <button class="btn btn-sm" data-roadmap-up="${list.id}" title="Move up" ${idx === 0 ? 'disabled' : ''}>↑</button>
+          <button class="btn btn-sm" data-roadmap-down="${list.id}" title="Move down" ${idx === total - 1 ? 'disabled' : ''}>↓</button>
+        </div>
+        <button class="btn btn-sm" data-roadmap-open="${list.id}">🛡️ Open</button>
+        <button class="btn btn-sm btn-danger" data-roadmap-remove="${list.id}">Remove</button>
+      </div>
+    </div>
+  `;
+}
+
+function availableListRow(list) {
+  const col = appData.collections[list.collectionId];
+  const sys = col ? GAME_SYSTEMS[col.gameSystemId] : null;
+  const stats = listStats(list);
+  return `
+    <div class="roadmap-available-row">
+      <span class="roadmap-available-name">${list.name}</span>
+      ${sys ? `<span class="sys-tag ${sys.theme}">${sys.shortLabel}</span>` : ''}
+      <span class="roadmap-available-count">${stats.total} model${stats.total !== 1 ? 's' : ''}</span>
+      <button class="btn btn-sm btn-primary" data-roadmap-add="${list.id}">+ Add to Roadmap</button>
+    </div>
+  `;
+}


### PR DESCRIPTION
Army lists can now be marked "on the roadmap" as active campaigns, from
either the new Roadmap tab or a toggle on the list detail view. The Model
Pool splits accordingly: models on an active campaign surface at the top,
while everything else collapses into a "Backlog / Future Work" section —
addressing the feeling of an overwhelming, undifferentiated pool.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_014RJWEqU91zRYSsmT9U2djo