### PR TITLE
Move roadmap model list out of Model Pool and into the Roadmap tab

### DIFF
--- a/index.html
+++ b/index.html
@@ -1843,11 +1843,6 @@
     .folder-empty { font-size: 0.85em; color: var(--text-muted); font-style: italic; padding: 0.25em 0; }
     .folder-unfiled .folder-header { background: var(--bg2); }
 
-    /* Roadmap group / backlog wrapper (reuse folder-section chrome) */
-    .pool-section-label { font-size: 0.78em; font-weight: 600; text-transform: uppercase; letter-spacing: 0.04em; color: var(--text-muted); margin: 0.2em 0 0.5em; }
-    .folder-section.roadmap-group { border-color: var(--accent); }
-    .folder-section.backlog-section { margin-top: 1em; }
-
     /* ================================================================
        ROADMAP TAB
     ================================================================ */
@@ -1866,6 +1861,16 @@
     .roadmap-available-row { display: flex; align-items: center; gap: 0.6em; background: var(--surface); border: 1px solid var(--border); border-radius: var(--radius); padding: 0.5em 0.75em; flex-wrap: wrap; }
     .roadmap-available-name { font-weight: 600; }
     .roadmap-available-count { font-size: 0.8em; color: var(--text-muted); margin-left: auto; }
+
+    .roadmap-campaign-models { margin-top: 0.75em; padding-top: 0.6em; border-top: 1px solid var(--border); display: flex; flex-direction: column; gap: 0.4em; }
+    .roadmap-model-row { display: flex; align-items: center; gap: 0.6em; cursor: pointer; padding: 0.3em 0; }
+    .roadmap-model-row:hover .roadmap-model-name { color: var(--accent); }
+    .roadmap-model-name { flex: 0 0 auto; font-size: 0.88em; }
+    .roadmap-model-qty { color: var(--text-muted); font-size: 0.85em; }
+    .roadmap-model-row .prog-bar { flex: 1; }
+    .roadmap-finished-toggle { align-self: flex-start; background: none; border: none; color: var(--text-muted); padding: 0.2em 0; }
+    .roadmap-finished-toggle:hover { color: var(--text); }
+    .roadmap-finished-list { display: flex; flex-direction: column; gap: 0.4em; opacity: 0.75; }
 
     /* ================================================================
        POOL SELECT MODE / MASS MOVE

--- a/js/models.js
+++ b/js/models.js
@@ -5,7 +5,7 @@ import {
   logProgress, logSession, modelPoints, modelThreshold, stageCap, uid, saveData,
   getAllModelTypes, saveCustomModelType, deleteCustomModelType,
   saveModelTypeOverride, resetModelTypeOverride, BUILTIN_MODEL_TYPES, TYPE_GROUPS,
-  createFolder, updateFolder, deleteFolder, getAllFolders, getRoadmapLists
+  createFolder, updateFolder, deleteFolder, getAllFolders
 } from './data.js';
 import { showModal, closeModal, toast, progressBar, thresholdBadge, stageRow, today, createDateInput, getDateValue, createTimeInput } from './ui.js';
 import { getTerm } from './theme.js';
@@ -14,10 +14,6 @@ import { compressImageToBase64, IMAGE_SIZE_PRESETS } from './imageUtils.js';
 // Select mode state for mass move
 let _selectMode = false;
 let _selectedIds = new Set();
-
-// Backlog section collapse state — defaults to collapsed once the roadmap is
-// actually in use, so first-time users still see everything at a glance.
-let _backlogCollapsed = null;
 
 // Lazy import to avoid circular dependency
 async function pruneQueues() {
@@ -70,17 +66,10 @@ export function renderModelPool(containerId = 'modelPool') {
     return;
   }
 
-  const hasLists = Object.keys(appData.lists || {}).length > 0;
-  const roadmapLists = getRoadmapLists();
-  const roadmapModelIds = new Set();
-  roadmapLists.forEach(l => (l.modelIds || []).forEach(id => roadmapModelIds.add(id)));
-  const backlogModels = allModels.filter(m => !roadmapModelIds.has(m.id));
-
-  // Group backlog models by folder — roadmap models are pulled out into their
-  // own section above, regardless of which folder they happen to be filed in.
+  // Group models by folder
   const byFolder = {};
   const unfiled = [];
-  backlogModels.forEach(m => {
+  allModels.forEach(m => {
     if (m.folderId && appData.folders[m.folderId]) {
       if (!byFolder[m.folderId]) byFolder[m.folderId] = [];
       byFolder[m.folderId].push(m);
@@ -89,105 +78,57 @@ export function renderModelPool(containerId = 'modelPool') {
     }
   });
 
+  const hasLists = Object.keys(appData.lists || {}).length > 0;
   let html = '';
 
-  // --- On the Roadmap ---
-  if (roadmapLists.length) {
-    const groups = roadmapLists.map(list => {
-      const models = (list.modelIds || []).map(id => appData.models[id]).filter(Boolean);
-      if (!models.length) return '';
-      return `
-        <div class="folder-section roadmap-group">
-          <div class="folder-header">
-            <div class="folder-toggle">
-              <span class="folder-icon">🗺️</span>
-              <span class="folder-name">${list.name}</span>
-              <span class="folder-count">${models.length}</span>
-            </div>
-          </div>
-          <div class="folder-models">
-            <div class="model-grid">${models.map(modelCard).join('')}</div>
-          </div>
-        </div>
-      `;
-    }).join('');
-    if (groups) html += `<div class="pool-section-label">🗺️ On the Roadmap</div>${groups}`;
-  } else if (hasLists) {
-    html += `<div class="army-nudge roadmap-nudge">
-      <span class="army-nudge-icon">🗺️</span>
-      <div class="army-nudge-body">
-        <b>Nothing on the roadmap yet</b>
-        <span>Mark an army list active in the Roadmap tab to pull it out of the backlog and keep it top of mind.</span>
-      </div>
-      <button class="btn btn-sm btn-primary" id="nudgeRoadmapBtn">Roadmap →</button>
-    </div>`;
-  }
-
-  // --- Backlog / Future Work (everything not on the roadmap) ---
-  // Until the user has manually toggled it, default to collapsed as soon as the
-  // roadmap has any active campaigns (recomputed live so it isn't stuck at
-  // whatever the roadmap looked like the first time a backlog existed).
-  const backlogCollapsed = _backlogCollapsed === null ? roadmapLists.length > 0 : _backlogCollapsed;
-
-  if (backlogModels.length > 0 || folders.length > 0) {
-    let backlogInner = '';
-    folders.forEach(folder => {
-      const models = byFolder[folder.id] || [];
-      const collapsed = folder.collapsed;
-      backlogInner += `
-        <div class="folder-section" data-folder-id="${folder.id}">
-          <div class="folder-header">
-            <button class="folder-toggle" data-toggle-folder="${folder.id}">
-              <span class="folder-chevron">${collapsed ? '▶' : '▼'}</span>
-              <span class="folder-icon">📁</span>
-              <span class="folder-name">${folder.name}</span>
-              <span class="folder-count">${models.length}</span>
-            </button>
-            <div class="folder-actions">
-              <button class="btn btn-xs btn-primary" data-add-in-folder="${folder.id}">+</button>
-              <button class="btn btn-xs" data-rename-folder="${folder.id}">✏️</button>
-              <button class="btn btn-xs btn-danger" data-delete-folder="${folder.id}">🗑️</button>
-            </div>
-          </div>
-          ${collapsed ? '' : `
-            <div class="folder-models">
-              ${models.length ? `<div class="model-grid">${models.map(modelCard).join('')}</div>` : `<p class="folder-empty">No models in this folder.</p>`}
-            </div>
-          `}
-        </div>
-      `;
-    });
-
-    if (unfiled.length > 0) {
-      backlogInner += `
-        <div class="folder-section folder-unfiled">
-          <div class="folder-header">
-            <div class="folder-toggle">
-              <span class="folder-icon">📂</span>
-              <span class="folder-name">Unfiled</span>
-              <span class="folder-count">${unfiled.length}</span>
-            </div>
-          </div>
-          <div class="folder-models">
-            <div class="model-grid">${unfiled.map(modelCard).join('')}</div>
-          </div>
-        </div>
-      `;
-    }
-
+  // Render each folder
+  folders.forEach(folder => {
+    const models = byFolder[folder.id] || [];
+    const collapsed = folder.collapsed;
     html += `
-      <div class="folder-section backlog-section">
+      <div class="folder-section" data-folder-id="${folder.id}">
         <div class="folder-header">
-          <button class="folder-toggle" id="backlogToggle">
-            <span class="folder-chevron">${backlogCollapsed ? '▶' : '▼'}</span>
-            <span class="folder-icon">📦</span>
-            <span class="folder-name">Backlog / Future Work</span>
-            <span class="folder-count">${backlogModels.length}</span>
+          <button class="folder-toggle" data-toggle-folder="${folder.id}">
+            <span class="folder-chevron">${collapsed ? '▶' : '▼'}</span>
+            <span class="folder-icon">📁</span>
+            <span class="folder-name">${folder.name}</span>
+            <span class="folder-count">${models.length}</span>
           </button>
+          <div class="folder-actions">
+            <button class="btn btn-xs btn-primary" data-add-in-folder="${folder.id}">+</button>
+            <button class="btn btn-xs" data-rename-folder="${folder.id}">✏️</button>
+            <button class="btn btn-xs btn-danger" data-delete-folder="${folder.id}">🗑️</button>
+          </div>
         </div>
-        ${backlogCollapsed ? '' : `<div class="folder-models">${backlogInner}</div>`}
+        ${collapsed ? '' : `
+          <div class="folder-models">
+            ${models.length ? `<div class="model-grid">${models.map(modelCard).join('')}</div>` : `<p class="folder-empty">No models in this folder.</p>`}
+          </div>
+        `}
       </div>
     `;
+  });
+
+  // Unfiled models
+  if (unfiled.length > 0) {
+    html += `
+      <div class="folder-section folder-unfiled">
+        <div class="folder-header">
+          <div class="folder-toggle">
+            <span class="folder-icon">📂</span>
+            <span class="folder-name">Unfiled</span>
+            <span class="folder-count">${unfiled.length}</span>
+          </div>
+        </div>
+        <div class="folder-models">
+          <div class="model-grid">${unfiled.map(modelCard).join('')}</div>
+        </div>
+      </div>
+    `;
+  }
+
+  if (!html) {
+    html = `<div class="empty-state"><p>No models yet. Use the + button to add one.</p></div>`;
   }
 
   if (!hasLists) {
@@ -232,15 +173,6 @@ export function renderModelPool(containerId = 'modelPool') {
 
   container.querySelector('#nudgeArmiesBtn')?.addEventListener('click', () => {
     document.querySelector('.nav-tab[data-tab="collections"]')?.click();
-  });
-
-  container.querySelector('#nudgeRoadmapBtn')?.addEventListener('click', () => {
-    document.querySelector('.nav-tab[data-tab="roadmap"]')?.click();
-  });
-
-  container.querySelector('#backlogToggle')?.addEventListener('click', () => {
-    _backlogCollapsed = !backlogCollapsed;
-    renderModelPool(containerId);
   });
 
   // Select mode controls

--- a/js/roadmap.js
+++ b/js/roadmap.js
@@ -2,11 +2,15 @@
 // vs. everything else sitting quietly in the backlog
 
 import {
-  appData, GAME_SYSTEMS, listStats,
+  appData, GAME_SYSTEMS, listStats, modelPoints, modelThreshold,
   getRoadmapLists, addListToRoadmap, removeListFromRoadmap, moveRoadmapList
 } from './data.js';
-import { toast, progressBar, formatDate, daysUntil } from './ui.js';
+import { toast, progressBar, thresholdBadge, formatDate, daysUntil } from './ui.js';
 import { selectCollection, selectList } from './collections.js';
+import { showModelDetail } from './models.js';
+
+// List ids whose finished models are currently expanded (collapsed by default).
+const _showFinishedFor = new Set();
 
 export function renderRoadmap(containerId = 'roadmapView') {
   const container = document.getElementById(containerId);
@@ -31,7 +35,7 @@ export function renderRoadmap(containerId = 'roadmapView') {
             <span class="step-num">2</span>
             <div>
               <b>Add it to the Roadmap</b>
-              <p>Come back here and mark it active — its models pop out of the backlog on the Model Pool.</p>
+              <p>Come back here and mark it active to track its remaining work right here.</p>
             </div>
           </div>
         </div>
@@ -50,7 +54,7 @@ export function renderRoadmap(containerId = 'roadmapView') {
     <div class="panel-header">
       <h2>🗺️ Roadmap</h2>
     </div>
-    <p class="roadmap-intro">Campaigns below are your active, in-focus work. Everything else waits quietly in the Model Pool's Backlog section until you're ready for it.</p>
+    <p class="roadmap-intro">Campaigns below are your active, in-focus work — everything else can wait.</p>
     ${roadmapLists.length ? `
       <div class="roadmap-campaigns">
         ${roadmapLists.map((list, idx) => campaignCard(list, idx, roadmapLists.length)).join('')}
@@ -106,6 +110,17 @@ export function renderRoadmap(containerId = 'roadmapView') {
       selectList(list.id);
     });
   });
+  container.querySelectorAll('[data-roadmap-finished-toggle]').forEach(btn => {
+    btn.addEventListener('click', () => {
+      const listId = btn.dataset.roadmapFinishedToggle;
+      if (_showFinishedFor.has(listId)) _showFinishedFor.delete(listId);
+      else _showFinishedFor.add(listId);
+      renderRoadmap(containerId);
+    });
+  });
+  container.querySelectorAll('[data-roadmap-model-view]').forEach(el => {
+    el.addEventListener('click', () => showModelDetail(el.dataset.roadmapModelView));
+  });
 }
 
 function campaignCard(list, idx, total) {
@@ -120,6 +135,11 @@ function campaignCard(list, idx, total) {
     const daysStr = days < 0 ? `${Math.abs(days)} days overdue` : days === 0 ? 'due today' : `${days} days to go`;
     deadlineHtml = `<span class="roadmap-deadline">🎯 ${dateStr} · ${daysStr}</span>`;
   }
+
+  const models = (list.modelIds || []).map(id => appData.models[id]).filter(Boolean);
+  const activeModels = models.filter(m => modelThreshold(m) !== 'finished');
+  const finishedModels = models.filter(m => modelThreshold(m) === 'finished');
+  const showFinished = _showFinishedFor.has(list.id);
 
   return `
     <div class="roadmap-campaign-card" data-list-id="${list.id}">
@@ -142,6 +162,29 @@ function campaignCard(list, idx, total) {
         <button class="btn btn-sm" data-roadmap-open="${list.id}">🛡️ Open</button>
         <button class="btn btn-sm btn-danger" data-roadmap-remove="${list.id}">Remove</button>
       </div>
+      <div class="roadmap-campaign-models">
+        ${activeModels.length
+          ? activeModels.map(campaignModelRow).join('')
+          : `<p class="folder-empty">Nothing left unfinished in this campaign.</p>`}
+        ${finishedModels.length ? `
+          <button class="btn btn-sm roadmap-finished-toggle" data-roadmap-finished-toggle="${list.id}">
+            ${showFinished ? '▼' : '▶'} 🏆 ${finishedModels.length} finished
+          </button>
+          ${showFinished ? `<div class="roadmap-finished-list">${finishedModels.map(campaignModelRow).join('')}</div>` : ''}
+        ` : ''}
+      </div>
+    </div>
+  `;
+}
+
+function campaignModelRow(model) {
+  const pts = modelPoints(model);
+  const thresh = modelThreshold(model);
+  return `
+    <div class="roadmap-model-row" data-roadmap-model-view="${model.id}">
+      <span class="roadmap-model-name">${model.name} <span class="roadmap-model-qty">×${model.quantity}</span></span>
+      ${progressBar(pts.pct)}
+      ${thresholdBadge(thresh)}
     </div>
   `;
 }


### PR DESCRIPTION
Model Pool goes back to its plain folder view — no more special "on the roadmap" grouping or collapsible backlog wrapper cluttering it. Instead, each campaign card on the Roadmap tab now lists its own models directly, with finished ones collapsed behind a toggle so the campaign reads as "what's left" rather than a full roster.


Claude-Session: https://claude.ai/code/session_014RJWEqU91zRYSsmT9U2djo