### PR TITLE
Add pile-clearing gamification: fireworks, bounties, Hall of Fame, badges

### DIFF
--- a/index.html
+++ b/index.html
@@ -1079,6 +1079,39 @@
 
     .pile-total.shame-heavy { color: var(--danger); font-weight: 600; }
 
+    /* Fireworks celebration overlay */
+    .fireworks-overlay { position: fixed; inset: 0; pointer-events: none; z-index: 9999; }
+
+    /* Bounty Board */
+    .dash-bounty { grid-column: 1 / -1; }
+    .bounty-active { display: flex; flex-direction: column; gap: 0.4em; align-items: flex-start; }
+    .bounty-model-name { font-size: 1.1em; font-weight: 700; font-family: var(--font-display); }
+    .bounty-model-age { font-size: 0.82em; color: var(--text-muted); }
+    .bounty-active .prog-bar { width: 100%; }
+    .bounty-reward { font-size: 0.9em; }
+    .bounty-reward-label { color: var(--text-muted); margin-right: 0.3em; }
+
+    /* Hall of Fame */
+    .dash-hall-of-fame { grid-column: 1 / -1; }
+    .hof-list { display: flex; flex-direction: column; gap: 0.6em; }
+    .hof-item { display: flex; gap: 0.7em; align-items: flex-start; padding: 0.4em 0; border-bottom: 1px solid var(--border); }
+    .hof-item:last-child { border-bottom: none; }
+    .hof-tier { font-size: 1.4em; line-height: 1; }
+    .hof-item-name { font-weight: 600; }
+    .hof-item-meta { font-size: 0.78em; color: var(--text-muted); }
+    .hof-item-reward { font-size: 0.85em; margin-top: 0.15em; }
+
+    /* Badges */
+    .dash-badges { grid-column: 1 / -1; }
+    .badge-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(120px, 1fr)); gap: 0.6em; }
+    .badge-tile { display: flex; flex-direction: column; align-items: center; text-align: center; gap: 0.2em; padding: 0.7em 0.4em; border-radius: var(--radius); border: 1px solid var(--border); background: var(--surface2); }
+    .badge-tile-icon { font-size: 1.8em; }
+    .badge-tile-name { font-size: 0.8em; font-weight: 600; }
+    .badge-tile-date { font-size: 0.7em; color: var(--text-muted); }
+    .badge-tile-desc { font-size: 0.7em; color: var(--text-muted); }
+    .badge-tile-locked { opacity: 0.45; filter: grayscale(1); }
+    .badge-tile-earned { border-color: var(--accent); }
+
     /* Ledger tab: a dense transaction record, grouped by month */
     .ledger-month-group { margin-bottom: 1em; }
     .ledger-month-header { display: flex; justify-content: space-between; font-size: 0.8em; font-weight: 600; text-transform: uppercase; letter-spacing: 0.03em; color: var(--text-muted); padding-bottom: 0.25em; margin-bottom: 0.2em; border-bottom: 1px solid var(--border); }
@@ -2303,7 +2336,7 @@
 </div>
 
 <script type="module">
-  import { loadData, exportJSON, importJSON, appData, getAllModelTypes, deleteCustomModelType, BUILTIN_MODEL_TYPES, createFolder, driveSync, replaceData } from './js/data.js';
+  import { loadData, exportJSON, importJSON, appData, getAllModelTypes, deleteCustomModelType, BUILTIN_MODEL_TYPES, createFolder, driveSync, dataChangeHook, replaceData } from './js/data.js';
   import { isConfigured, isConnected, wasConnected, getSavedEmail, getLastSyncTime, init as gDriveInit, connect as gDriveConnect, disconnect as gDriveDisconnect, loadFromDrive, saveToDrive } from './js/gdrive.js';
   import { renderModelPool, showModelForm, showModelTypeEditor } from './js/models.js';
   import { renderCollections } from './js/collections.js';
@@ -2315,11 +2348,18 @@
   import { toast, showModal, closeModal, showConfirm } from './js/ui.js';
   import { renderQuartermaster, pileCount, pileWorth, rectitudePct } from './js/quartermaster.js';
   import { openTipsModal, refreshTipsBadge } from './js/tips.js';
+  import { checkGamification } from './js/badges.js';
 
   // --- Boot ---
   loadData();
   loadSavedTheme();
   refreshTipsBadge();
+
+  // --- Gamification: badges, bounty, hall of fame ---
+  dataChangeHook.callback = checkGamification;
+  // Silent backfill on load — badges already earned before this feature
+  // existed shouldn't trigger a celebration on every app open.
+  checkGamification({ silent: true });
 
   // --- Drive sync ---
   let _driveSyncTimer = null;

--- a/js/badges.js
+++ b/js/badges.js
@@ -1,0 +1,272 @@
+// badges.js — pile-clearing gamification: bounties, the Hall of Fame, and badges
+//
+// A "bounty" is a self-defined reward for finishing the oldest thing in the
+// pile: you pick the reward (a treat, a kit, bragging rights), the app just
+// holds you to it and makes the payoff feel like an event when it lands.
+
+import {
+  appData, saveData, uid, globalStats, getAllModels, unstartedCount, modelThreshold,
+  modelPoints, greyBrigadeCount, getModelDateAdded,
+  setBounty, clearBounty, addHallOfFameEntry, recordBadgeEarned
+} from './data.js';
+import { toast, showModal, closeModal, formatDate, fireworks, progressBar } from './ui.js';
+
+// --- Badge definitions ---
+
+export const BADGES = [
+  {
+    id: 'first_blood',
+    icon: '🩸',
+    name: 'First Blood',
+    desc: 'Finish your very first model.',
+    check: () => globalStats().finished >= 1
+  },
+  {
+    id: 'century_club',
+    icon: '💯',
+    name: 'Century Club',
+    desc: 'Finish 100 models.',
+    check: () => globalStats().finished >= 100
+  },
+  {
+    id: 'zero_shame',
+    icon: '✨',
+    name: 'Zero Shame',
+    desc: 'Empty the Pile of Potential — nothing left on the sprue.',
+    check: () => {
+      const models = getAllModels();
+      return models.length > 0 && models.every(m => unstartedCount(m) === 0);
+    }
+  },
+  {
+    id: 'sprue_slayer',
+    icon: '🩶',
+    name: 'Sprue Slayer',
+    desc: 'Clear the Grey Brigade — nothing left assembled-but-unpainted.',
+    check: () => {
+      const models = getAllModels();
+      const anyEverAssembled = models.some(m => modelThreshold(m) !== 'not_started');
+      return anyEverAssembled && models.every(m => greyBrigadeCount(m) === 0);
+    }
+  },
+  {
+    id: 'bounty_hunter',
+    icon: '🎯',
+    name: 'Bounty Hunter',
+    desc: 'Complete your first bounty.',
+    check: () => (appData.hallOfFame || []).length >= 1
+  },
+  {
+    id: 'bounty_hunter_5',
+    icon: '🏹',
+    name: 'Veteran Bounty Hunter',
+    desc: 'Complete 5 bounties.',
+    check: () => (appData.hallOfFame || []).length >= 5
+  },
+  {
+    id: 'ancient_slain',
+    icon: '🥇',
+    name: 'Ancient Slain',
+    desc: 'Complete a bounty on something a year or older.',
+    check: () => (appData.hallOfFame || []).some(h => h.ageDays >= 365)
+  }
+];
+
+function bountyTier(ageDays) {
+  if (ageDays >= 365) return { tier: 'gold', icon: '🥇' };
+  if (ageDays >= 180) return { tier: 'silver', icon: '🥈' };
+  return { tier: 'bronze', icon: '🥉' };
+}
+
+// The oldest model still sitting on the sprue — the default bounty target.
+export function oldestPileModel() {
+  const candidates = getAllModels()
+    .map(m => ({ model: m, added: getModelDateAdded(m) }))
+    .filter(e => unstartedCount(e.model) > 0);
+  if (!candidates.length) return null;
+  candidates.sort((a, b) => {
+    const at = a.added ? a.added.getTime() : Infinity;
+    const bt = b.added ? b.added.getTime() : Infinity;
+    return at - bt;
+  });
+  return candidates[0].model;
+}
+
+function ageDaysOf(model) {
+  const added = getModelDateAdded(model);
+  return added ? Math.floor((Date.now() - added.getTime()) / 86400000) : 0;
+}
+
+// --- Gamification checks, run after every data change ---
+
+let _checking = false;
+
+export function checkGamification({ silent = false } = {}) {
+  if (_checking) return;
+  _checking = true;
+  try {
+    checkBountyCompletion(silent);
+    checkBadges(silent);
+  } finally {
+    _checking = false;
+  }
+}
+
+function checkBountyCompletion(silent) {
+  const bounty = appData.bounty;
+  if (!bounty) return;
+  const model = appData.models[bounty.modelId];
+  if (!model) { clearBounty(); return; }
+  if (modelThreshold(model) !== 'finished') return;
+
+  const ageDays = ageDaysOf(model);
+  const tier = bountyTier(ageDays);
+  addHallOfFameEntry({
+    id: uid(),
+    modelName: model.name,
+    ageDays,
+    dateCompleted: new Date().toISOString().slice(0, 10),
+    reward: bounty.reward,
+    tier: tier.tier
+  });
+  clearBounty();
+
+  if (!silent) {
+    fireworks();
+    toast(`${tier.icon} Bounty complete! ${model.name} is finished — go claim: ${bounty.reward}`, 'success', 5500);
+  }
+}
+
+function checkBadges(silent) {
+  if (!appData.badges) appData.badges = {};
+  BADGES.forEach(b => {
+    if (appData.badges[b.id]) return;
+    if (b.check()) {
+      recordBadgeEarned(b.id);
+      if (!silent) toast(`🎖️ Badge earned: ${b.name}`, 'success', 4500);
+    }
+  });
+}
+
+// --- Rendering ---
+
+function escAttr(s) {
+  return String(s).replace(/&/g, '&amp;').replace(/"/g, '&quot;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+}
+
+export function renderBountySection() {
+  const bounty = appData.bounty;
+
+  if (bounty) {
+    const model = appData.models[bounty.modelId];
+    if (!model) { clearBounty(); return renderBountySection(); }
+    const ageDays = ageDaysOf(model);
+    const pts = modelPoints(model);
+    return `
+      <div class="dash-card dash-bounty">
+        <h3>🎯 Bounty Board</h3>
+        <div class="bounty-active">
+          <div class="bounty-model-name">${escAttr(model.name)}</div>
+          <div class="bounty-model-age">${ageDays} day${ageDays !== 1 ? 's' : ''} old</div>
+          ${progressBar(pts.pct)}
+          <div class="bounty-reward"><span class="bounty-reward-label">Reward:</span> ${escAttr(bounty.reward)}</div>
+          <button class="btn btn-sm btn-danger" id="abandonBountyBtn">Abandon Bounty</button>
+        </div>
+      </div>`;
+  }
+
+  const target = oldestPileModel();
+  return `
+    <div class="dash-card dash-bounty">
+      <h3>🎯 Bounty Board</h3>
+      ${target
+        ? `<p class="empty-text">Set a bounty on the oldest thing in your pile — pick your own reward, and finish it to collect.</p>
+           <button class="btn btn-sm btn-primary" id="setBountyBtn">🎯 Set a Bounty</button>`
+        : `<p class="empty-text">Nothing on the pile to put a bounty on. Impressive!</p>`}
+    </div>`;
+}
+
+export function wireBountySection(container, onChange) {
+  container.querySelector('#setBountyBtn')?.addEventListener('click', () => {
+    const target = oldestPileModel();
+    if (!target) return;
+    showSetBountyModal(target, onChange);
+  });
+  container.querySelector('#abandonBountyBtn')?.addEventListener('click', () => {
+    clearBounty();
+    toast('Bounty abandoned', 'info');
+    onChange?.();
+  });
+}
+
+function showSetBountyModal(model, onChange) {
+  const ageDays = ageDaysOf(model);
+  const content = document.createElement('div');
+  content.innerHTML = `
+    <p style="font-size:0.9em;color:var(--text-muted);margin-bottom:0.75em">
+      Oldest thing on your pile — <b>${escAttr(model.name)}</b>, ${ageDays} day${ageDays !== 1 ? 's' : ''} old.
+      Finish it (reach 🏆 Finished) to collect.
+    </p>
+    <label>What's the reward?</label>
+    <input type="text" class="form-input" id="bountyRewardInput" placeholder="e.g. a new brush, that kit I've been eyeing…" maxlength="120">
+    <div class="modal-actions">
+      <button class="btn btn-primary" id="bountySaveBtn">Set Bounty</button>
+      <button class="btn" id="bountyCancelBtn">Cancel</button>
+    </div>
+  `;
+  content.querySelector('#bountySaveBtn').addEventListener('click', () => {
+    const reward = content.querySelector('#bountyRewardInput').value.trim();
+    if (!reward) { toast('Enter a reward first', 'error'); return; }
+    setBounty(model.id, reward);
+    closeModal();
+    toast('Bounty set — go clear it!', 'success');
+    onChange?.();
+  });
+  content.querySelector('#bountyCancelBtn').addEventListener('click', () => closeModal());
+  showModal({ title: '🎯 Set a Bounty', content });
+}
+
+export function renderHallOfFameSection() {
+  const entries = appData.hallOfFame || [];
+  return `
+    <div class="dash-card dash-hall-of-fame">
+      <h3>🏛️ Hall of Fame</h3>
+      ${entries.length ? `
+        <div class="hof-list">
+          ${entries.map(e => {
+            const tierIcon = { gold: '🥇', silver: '🥈', bronze: '🥉' }[e.tier] || '🏅';
+            return `
+              <div class="hof-item">
+                <span class="hof-tier">${tierIcon}</span>
+                <div class="hof-item-body">
+                  <div class="hof-item-name">${escAttr(e.modelName)}</div>
+                  <div class="hof-item-meta">${e.ageDays} day${e.ageDays !== 1 ? 's' : ''} old · finished ${formatDate(e.dateCompleted, { day: 'numeric', month: 'short', year: 'numeric' })}</div>
+                  <div class="hof-item-reward">🎁 ${escAttr(e.reward)}</div>
+                </div>
+              </div>`;
+          }).join('')}
+        </div>
+      ` : `<p class="empty-text">No bounties completed yet — set one on the Bounty Board above.</p>`}
+    </div>`;
+}
+
+export function renderBadgesSection() {
+  const earned = appData.badges || {};
+  return `
+    <div class="dash-card dash-badges">
+      <h3>🎖️ Badges</h3>
+      <div class="badge-grid">
+        ${BADGES.map(b => {
+          const dateEarned = earned[b.id];
+          return `
+            <div class="badge-tile ${dateEarned ? 'badge-tile-earned' : 'badge-tile-locked'}" title="${escAttr(b.desc)}">
+              <div class="badge-tile-icon">${b.icon}</div>
+              <div class="badge-tile-name">${b.name}</div>
+              ${dateEarned
+                ? `<div class="badge-tile-date">${formatDate(dateEarned, { day: 'numeric', month: 'short', year: 'numeric' })}</div>`
+                : `<div class="badge-tile-desc">${escAttr(b.desc)}</div>`}
+            </div>`;
+        }).join('')}
+      </div>
+    </div>`;
+}

--- a/js/collections.js
+++ b/js/collections.js
@@ -7,7 +7,7 @@ import {
   listStats, saveData, uid, GAME_SYSTEMS, modelPoints, modelThreshold,
   addListToRoadmap, removeListFromRoadmap
 } from './data.js';
-import { showModal, closeModal, showConfirm, toast, progressBar, thresholdBadge, createDateInput, getDateValue, formatDate } from './ui.js';
+import { showModal, closeModal, showConfirm, toast, progressBar, thresholdBadge, createDateInput, getDateValue, formatDate, fireworks } from './ui.js';
 import { applyTheme, resetTheme, setCurrentSystem, resetCurrentSystem, getTerm } from './theme.js';
 import { showLogProgress, showModelDetail } from './models.js';
 import { renderListCompletionPie, pieModeToggleHtml, wirePieModeToggle } from './charts.js';
@@ -208,6 +208,7 @@ export function selectCollection(colId) {
 }
 
 export function selectList(listId) {
+  const isNewView = activeListId !== listId;
   activeListId = listId;
   const list = appData.lists[listId];
   if (!list) return;
@@ -316,6 +317,12 @@ export function selectList(listId) {
   });
   wirePieModeToggle(main, () => selectList(listId));
   requestAnimationFrame(() => renderListCompletionPie('listCompletionPieChart', models));
+
+  // Fireworks when navigating into a completed campaign — once per visit,
+  // not on every internal refresh (deadline edits, etc.) while already here.
+  if (isNewView && list.onRoadmap && stats.totalPts > 0 && stats.totalPts - stats.donePts <= 0) {
+    fireworks();
+  }
 }
 
 function listModelRow(model, listId) {

--- a/js/dashboard.js
+++ b/js/dashboard.js
@@ -1,9 +1,10 @@
 // dashboard.js — dashboard with pie charts and deadline cards
 
-import { appData, globalStats, listStats, saveData, GAME_SYSTEMS, modelThreshold, unstartedCount, singleModelPoints, getModelType, resolveModelGroup, MODEL_GROUP_ORDER } from './data.js';
+import { appData, globalStats, listStats, saveData, GAME_SYSTEMS, modelThreshold, unstartedCount, singleModelPoints, getModelType, resolveModelGroup, MODEL_GROUP_ORDER, getModelDateAdded, resolveGameSystemId, greyBrigadeCount } from './data.js';
 import { progressBar, toast, daysUntil, formatDate, localDateStr } from './ui.js';
 import { renderCompositionPie, renderCompletionPie, renderBurndown, renderStageBar, renderListCompletionPie, pieModeToggleHtml, wirePieModeToggle, renderPileBurndown, pileBurndownStats } from './charts.js';
 import { showModal, closeModal, createDateInput, getDateValue } from './ui.js';
+import { renderBountySection, wireBountySection, renderHallOfFameSection, renderBadgesSection } from './badges.js';
 
 export function renderDashboard() {
   const container = document.getElementById('dashboardView');
@@ -99,11 +100,20 @@ export function renderDashboard() {
       <!-- Pile of Potential -->
       ${pileOfPotentialSection()}
 
+      <!-- Bounty Board -->
+      ${renderBountySection()}
+
       <!-- Pile burndown -->
       ${pileBurndownSection()}
 
       <!-- Grey Brigade -->
       ${greyBrigadeSection()}
+
+      <!-- Hall of Fame -->
+      ${renderHallOfFameSection()}
+
+      <!-- Badges -->
+      ${renderBadgesSection()}
 
     </div>
   `;
@@ -118,6 +128,9 @@ export function renderDashboard() {
 
   // Grey Brigade share button
   document.getElementById('shareGreyBtn')?.addEventListener('click', shareGreyBrigade);
+
+  // Bounty Board buttons + modal
+  wireBountySection(container, () => renderDashboard());
 
   // Pictogram figures: click/Enter/Space reveals model name + type
   wirePictoFigs(container);
@@ -443,31 +456,6 @@ function armyCompletionSection() {
 
 // --- Pile of Potential ---
 
-export function resolveGameSystemId(model) {
-  if (model.gameSystemId) return model.gameSystemId;
-  // For manually created models, infer from whichever list they belong to
-  for (const list of Object.values(appData.lists)) {
-    if ((list.modelIds || []).includes(model.id)) {
-      const col = appData.collections?.[list.collectionId];
-      if (col?.gameSystemId) return col.gameSystemId;
-    }
-  }
-  return null;
-}
-
-function getModelDateAdded(model) {
-  if (model.dateAdded) return new Date(model.dateAdded);
-  // Derive from uid: Date.now().toString(36) prefix (8 chars for current timestamps)
-  const id = model.id || '';
-  for (const len of [8, 9]) {
-    if (id.length < len + 5) continue;
-    const ts = parseInt(id.slice(0, len), 36);
-    const year = new Date(ts).getFullYear();
-    if (year >= 2020 && year <= 2100) return new Date(ts);
-  }
-  return null;
-}
-
 function shameScore(model, unstarted) {
   if (unstarted === 0) return 0;
   let score = unstarted;
@@ -759,35 +747,6 @@ function showPileShareFallback(text) {
 }
 
 // --- Grey Brigade ---
-
-export function greyBrigadeCount(model) {
-  const stages = model.stages || appData.config.stages;
-  const skipped = model.skippedStages || [];
-
-  // This heuristic assumes a single ordered stage track; multi-part entries
-  // (hull + crew) don't map onto it, so skip them rather than report bogus counts.
-  if (stages.some(s => s.group === 'crew')) return 0;
-
-  const assemblyStage = stages.find(s => s.threshold === 'table_ready');
-  if (!assemblyStage) return 0;
-
-  const assembled = Math.min(model.progress[assemblyStage.id]?.done || 0, model.quantity);
-  if (assembled === 0) return 0;
-
-  // Stages after Prime (assemblyIdx + 2 onward) up to and including the painted threshold
-  const assemblyIdx = stages.indexOf(assemblyStage);
-  const paintedStage = stages.find(s => s.threshold === 'painted');
-  const paintedIdx = paintedStage ? stages.indexOf(paintedStage) : stages.length - 1;
-
-  const actualPaintingStages = stages
-    .slice(assemblyIdx + 2, paintedIdx + 1)
-    .filter(s => !skipped.includes(s.id));
-
-  const maxPainted = actualPaintingStages.reduce((max, s) =>
-    Math.max(max, model.progress[s.id]?.done || 0), 0);
-
-  return Math.max(0, assembled - maxPainted);
-}
 
 function greyBrigadeSection() {
   const withGrey = Object.values(appData.models)

--- a/js/data.js
+++ b/js/data.js
@@ -502,7 +502,13 @@ export let appData = {
   sprints: {},
   // id -> { id, name, gameSystemId, worth, reason, plannedMonth, collectionId, itemType, status, promotedModelId, purchaseDate }
   // itemType: 'model' (joins the pile on promotion) | 'gift' | 'codex' | 'sundry' (ledger-only, never joins the pile)
-  purchaseQueue: {}
+  purchaseQueue: {},
+  // The active "clear the oldest thing" bounty, or null: { id, modelId, reward, dateSet }
+  bounty: null,
+  // Completed bounties, newest first: [{ id, modelName, ageDays, dateCompleted, reward, tier }]
+  hallOfFame: [],
+  // Earned achievement badges: badgeId -> ISO date first earned
+  badges: {}
 };
 
 // Convert a UTC date string (YYYY-MM-DD) to the equivalent local date string.
@@ -543,6 +549,9 @@ export function loadData() {
         // data carries over untouched (they migrate in as dateless sprints).
         sprints: parsed.sprints || parsed.queues || {},
         purchaseQueue: parsed.purchaseQueue || {},
+        bounty: parsed.bounty || null,
+        hallOfFame: parsed.hallOfFame || [],
+        badges: parsed.badges || {},
         config: {
           stages: parsed.config?.stages || [...DEFAULT_STAGES],
           deadline: parsed.config?.deadline || null,
@@ -577,6 +586,7 @@ export function saveData() {
     console.error('Failed to save data:', e);
     alert('Could not save data — storage may be full.');
   }
+  dataChangeHook.callback?.();
 }
 
 // Replace all in-memory data with a parsed snapshot (e.g. loaded from Drive).
@@ -591,6 +601,9 @@ export function replaceData(parsed) {
     folders: parsed.folders || {},
     sprints: parsed.sprints || parsed.queues || {},
     purchaseQueue: parsed.purchaseQueue || {},
+    bounty: parsed.bounty || null,
+    hallOfFame: parsed.hallOfFame || [],
+    badges: parsed.badges || {},
     config: {
       stages: parsed.config?.stages || [...DEFAULT_STAGES],
       deadline: parsed.config?.deadline || null,
@@ -613,6 +626,9 @@ export function uid() {
 
 // Set by index.html to trigger a debounced Drive upload after every save.
 export const driveSync = { callback: null };
+
+// Set by index.html to run gamification checks (badges/bounty) after every save.
+export const dataChangeHook = { callback: null };
 
 // --- Model helpers ---
 
@@ -718,6 +734,64 @@ export function unstartedCount(model) {
   }
   const maxDone = activeStages.reduce((max, s) => Math.max(max, model.progress[s.id]?.done || 0), 0);
   return Math.max(0, model.quantity - maxDone);
+}
+
+// A model's dateAdded, or (for models predating that field) derived from its
+// uid's Date.now().toString(36) prefix — used for pile "shame" aging and for
+// picking/scoring the oldest thing in the pile.
+export function getModelDateAdded(model) {
+  if (model.dateAdded) return new Date(model.dateAdded);
+  const id = model.id || '';
+  for (const len of [8, 9]) {
+    if (id.length < len + 5) continue;
+    const ts = parseInt(id.slice(0, len), 36);
+    const year = new Date(ts).getFullYear();
+    if (year >= 2020 && year <= 2100) return new Date(ts);
+  }
+  return null;
+}
+
+export function resolveGameSystemId(model) {
+  if (model.gameSystemId) return model.gameSystemId;
+  // For manually created models, infer from whichever list they belong to
+  for (const list of Object.values(appData.lists)) {
+    if ((list.modelIds || []).includes(model.id)) {
+      const col = appData.collections?.[list.collectionId];
+      if (col?.gameSystemId) return col.gameSystemId;
+    }
+  }
+  return null;
+}
+
+// How many of a model's quantity are assembled/primed but not yet painted —
+// the "Grey Brigade". This heuristic assumes a single ordered stage track;
+// multi-part entries (hull + crew) don't map onto it, so skip them rather
+// than report bogus counts.
+export function greyBrigadeCount(model) {
+  const stages = model.stages || appData.config.stages;
+  const skipped = model.skippedStages || [];
+
+  if (stages.some(s => s.group === 'crew')) return 0;
+
+  const assemblyStage = stages.find(s => s.threshold === 'table_ready');
+  if (!assemblyStage) return 0;
+
+  const assembled = Math.min(model.progress[assemblyStage.id]?.done || 0, model.quantity);
+  if (assembled === 0) return 0;
+
+  // Stages after Prime (assemblyIdx + 2 onward) up to and including the painted threshold
+  const assemblyIdx = stages.indexOf(assemblyStage);
+  const paintedStage = stages.find(s => s.threshold === 'painted');
+  const paintedIdx = paintedStage ? stages.indexOf(paintedStage) : stages.length - 1;
+
+  const actualPaintingStages = stages
+    .slice(assemblyIdx + 2, paintedIdx + 1)
+    .filter(s => !skipped.includes(s.id));
+
+  const maxPainted = actualPaintingStages.reduce((max, s) =>
+    Math.max(max, model.progress[s.id]?.done || 0), 0);
+
+  return Math.max(0, assembled - maxPainted);
 }
 
 // Splits a unit's quantity across threshold tiers instead of bucketing the
@@ -1103,6 +1177,34 @@ export function deleteFolder(id) {
 
 export function getAllFolders() {
   return Object.values(appData.folders).sort((a, b) => a.name.localeCompare(b.name));
+}
+
+// --- Gamification: bounty, hall of fame, badges ---
+// A "bounty" is a self-defined reward for finishing the oldest thing in the
+// pile — the app can't know what motivates you, so it just holds you to
+// whatever you typed in and makes the payoff feel like an event.
+
+export function setBounty(modelId, reward) {
+  appData.bounty = { id: uid(), modelId, reward, dateSet: new Date().toISOString().slice(0, 10) };
+  saveData();
+}
+
+export function clearBounty() {
+  appData.bounty = null;
+  saveData();
+}
+
+export function addHallOfFameEntry(entry) {
+  if (!appData.hallOfFame) appData.hallOfFame = [];
+  appData.hallOfFame.unshift(entry);
+  saveData();
+}
+
+export function recordBadgeEarned(badgeId) {
+  if (!appData.badges) appData.badges = {};
+  if (appData.badges[badgeId]) return;
+  appData.badges[badgeId] = new Date().toISOString().slice(0, 10);
+  saveData();
 }
 
 // --- Export / Import ---

--- a/js/quartermaster.js
+++ b/js/quartermaster.js
@@ -1,9 +1,9 @@
 // quartermaster.js — Quartermaster's Office: purchase planning, valuation, and budget tracking
 
 import {
-  appData, saveData, uid, unstartedCount, createModel, updateModel, GAME_SYSTEMS
+  appData, saveData, uid, unstartedCount, createModel, updateModel, GAME_SYSTEMS,
+  resolveGameSystemId, greyBrigadeCount
 } from './data.js';
-import { resolveGameSystemId, greyBrigadeCount } from './dashboard.js';
 import { toast, today, formatDate } from './ui.js';
 
 // --- Data helpers ---

--- a/js/ui.js
+++ b/js/ui.js
@@ -58,6 +58,67 @@ export function closeModal(callback) {
   if (typeof callback === 'function') callback();
 }
 
+// --- Fireworks ---
+// A short celebratory burst, e.g. for viewing a completed campaign or
+// closing out a bounty. Self-contained canvas overlay, no dependencies.
+
+const FIREWORK_COLORS = ['#ff5252', '#ffd740', '#69f0ae', '#40c4ff', '#e040fb', '#ff9e40'];
+
+export function fireworks({ duration = 2200, bursts = 4 } = {}) {
+  const canvas = document.createElement('canvas');
+  canvas.className = 'fireworks-overlay';
+  canvas.width = window.innerWidth;
+  canvas.height = window.innerHeight;
+  document.body.appendChild(canvas);
+  const ctx = canvas.getContext('2d');
+
+  let particles = [];
+  const addBurst = (x, y) => {
+    const color = FIREWORK_COLORS[Math.floor(Math.random() * FIREWORK_COLORS.length)];
+    const count = 44 + Math.floor(Math.random() * 24);
+    for (let i = 0; i < count; i++) {
+      const angle = (Math.PI * 2 * i) / count + Math.random() * 0.25;
+      const speed = 2 + Math.random() * 3.5;
+      particles.push({
+        x, y, vx: Math.cos(angle) * speed, vy: Math.sin(angle) * speed,
+        life: 1, decay: 0.012 + Math.random() * 0.01, color, size: 2 + Math.random() * 2
+      });
+    }
+  };
+
+  const burstTimings = Array.from({ length: bursts }, (_, i) => i * (duration / (bursts + 1)));
+  const timers = burstTimings.map(t => setTimeout(() => {
+    addBurst(canvas.width * (0.2 + Math.random() * 0.6), canvas.height * (0.15 + Math.random() * 0.35));
+  }, t));
+
+  const start = performance.now();
+  let raf;
+  const frame = now => {
+    ctx.clearRect(0, 0, canvas.width, canvas.height);
+    particles.forEach(p => {
+      p.x += p.vx;
+      p.y += p.vy;
+      p.vy += 0.05;
+      p.life -= p.decay;
+      ctx.globalAlpha = Math.max(p.life, 0);
+      ctx.fillStyle = p.color;
+      ctx.beginPath();
+      ctx.arc(p.x, p.y, p.size, 0, Math.PI * 2);
+      ctx.fill();
+    });
+    particles = particles.filter(p => p.life > 0);
+    ctx.globalAlpha = 1;
+
+    if (now - start < duration + 800 || particles.length) {
+      raf = requestAnimationFrame(frame);
+    } else {
+      timers.forEach(clearTimeout);
+      canvas.remove();
+    }
+  };
+  raf = requestAnimationFrame(frame);
+}
+
 // --- Toast ---
 
 export function toast(message, type = 'info', duration = 2800) {


### PR DESCRIPTION
- Fireworks (canvas confetti burst) fire when you navigate into a completed
  campaign's detail view, once per visit rather than on every internal refresh.
- Bounty Board: set a self-defined reward for finishing the oldest thing on
  your pile; completing it fires fireworks, logs a tiered (bronze/silver/gold,
  by age) entry to a new Hall of Fame dashboard card, and clears the bounty.
- Badges: seven achievement badges (First Blood, Century Club, Zero Shame,
  Sprue Slayer, Bounty Hunter x2, Ancient Slain) tracked in a new dashboard
  card, checked automatically after every data change via a new
  dataChangeHook in data.js.
- Moved getModelDateAdded/resolveGameSystemId/greyBrigadeCount from
  dashboard.js into data.js so badges.js can reuse them without a circular
  import; dashboard.js and quartermaster.js now import them from data.js.