### PR TITLE
Fix sprint chunk quantity label overstating work remaining

### DIFF
--- a/js/data.js
+++ b/js/data.js
@@ -970,6 +970,23 @@ export function splitModelPoints(model, splitSize, offset) {
   return { total, done, pct: total ? Math.round(done / total * 100) : 0 };
 }
 
+// How many models within a virtual slice (most-finished-first ordering) have
+// already completed every active stage, i.e. need no further work this slice.
+// Used to tell "models bundled into this chunk" apart from "models in it that
+// still need painting" — a chunk can include already-finished models for free
+// (see chooseChunkSize in roadmap.js) so the two counts often differ.
+export function splitModelDoneCount(model, splitSize, offset) {
+  const stages = model.stages || appData.config.stages;
+  const skipped = model.skippedStages || [];
+  const activeStages = stages.filter(s => !skipped.includes(s.id));
+  if (!activeStages.length) return splitSize;
+  return activeStages.reduce((min, s) => {
+    const rawDone = model.progress[s.id]?.done || 0;
+    const splitDone = Math.max(0, Math.min(rawDone - offset, splitSize));
+    return Math.min(min, splitDone);
+  }, splitSize);
+}
+
 // Returns threshold for a virtual slice of a model (most-finished-first ordering).
 export function splitModelThreshold(model, splitSize, offset) {
   const stages = model.stages || appData.config.stages;

--- a/js/sprint.js
+++ b/js/sprint.js
@@ -3,7 +3,7 @@
 
 import {
   appData, saveData, uid, modelThreshold, modelPoints, getRoadmapLists,
-  splitModelPoints, splitModelThreshold
+  splitModelPoints, splitModelThreshold, splitModelDoneCount
 } from './data.js';
 import { showModal, closeModal, toast, thresholdBadge, progressBar, createDateInput, getDateValue, formatDate, today, addDays } from './ui.js';
 import { showLogProgress } from './models.js';
@@ -418,7 +418,15 @@ function sprintEntryCard(entry, idx, total, sprintId) {
   const pts = entryPoints(model, entry);
   const thresh = entryThreshold(model, entry);
   const isFirst = idx === 0;
-  const qtyLabel = isChunk ? `×${entry.chunkSize} of ${model.quantity}` : `×${model.quantity}`;
+  // A chunk can bundle in already-finished models for free (chooseChunkSize
+  // in roadmap.js counts them as zero remaining work), so the chunk size
+  // alone overstates how much painting this sprint actually needs.
+  const doneInChunk = isChunk ? splitModelDoneCount(model, entry.chunkSize, entry.chunkOffset || 0) : 0;
+  const qtyLabel = isChunk
+    ? (doneInChunk > 0
+      ? `×${entry.chunkSize - doneInChunk} of ${model.quantity}`
+      : `×${entry.chunkSize} of ${model.quantity}`)
+    : `×${model.quantity}`;
 
   return `
     <div class="queue-entry ${isFirst ? 'queue-entry-next' : ''}" data-entry-id="${entry.id}" data-sprint-id="${sprintId}">


### PR DESCRIPTION
Auto-planned sprint chunks bundle already-finished models in for free
(chooseChunkSize counts them as zero remaining points), but the label
displayed the raw chunk size, e.g. "x15 of 20" for a unit with 10 already
painted when only 5 more actually need work this sprint. Subtract the
already-done count within the chunk before displaying it.