### PR TITLE
Let projection unit types be edited, not just guessed

### DIFF
--- a/index.html
+++ b/index.html
@@ -1102,6 +1102,7 @@
     .qm-unit-owned { opacity: 0.6; }
     .qm-unit-owned .queue-entry-name { text-decoration: line-through; }
     .qm-unit-worth { width: 5.5em; display: inline-block; padding: 0.2em 0.4em; }
+    .qm-unit-type { width: auto; display: inline-block; padding: 0.2em 0.4em; font-size: 0.82em; }
     .qm-rating-row { display: flex; align-items: center; gap: 0.6em; padding: 0.3em 0; }
     .qm-rating-label { flex: 0 0 6em; font-size: 0.88em; }
     .qm-rating-stars { display: flex; gap: 0.1em; }

--- a/js/quartermaster.js
+++ b/js/quartermaster.js
@@ -1010,9 +1010,9 @@ function ratingRow(field, label, value) {
 }
 
 function projectionUnitRow(u, proj) {
-  const type = u.modelTypeId ? getModelType(u.modelTypeId) : null;
   const pts = unitHobbyPoints(u);
   const bundle = (proj.bundles || []).find(b => b.unitIds.includes(u.id));
+  const types = getAllModelTypes();
   return `
     <div class="queue-entry ${u.owned ? 'qm-unit-owned' : ''}" data-unit-id="${u.id}">
       <div class="queue-entry-main">
@@ -1021,7 +1021,10 @@ function projectionUnitRow(u, proj) {
             <input type="checkbox" data-unit-owned="${u.id}" ${u.owned ? 'checked' : ''}> Owned
           </label>
           <span class="queue-entry-name">${u.name} <span class="queue-entry-qty">×${u.quantity}</span></span>
-          ${type ? `<span class="sys-tag theme-default">${type.name}</span>` : ''}
+          <select class="form-input qm-unit-type" data-unit-type="${u.id}">
+            <option value="">— Generic —</option>
+            ${types.map(t => `<option value="${t.id}" ${u.modelTypeId === t.id ? 'selected' : ''}>${t.name}</option>`).join('')}
+          </select>
           ${bundle ? `<span class="qm-bundle-tag">🎁 ${bundle.name}</span>` : ''}
         </div>
         <div class="queue-entry-note">
@@ -1211,6 +1214,12 @@ function renderProjectionDetail(body, container, projId) {
     inp.addEventListener('input', e => {
       updateProjectionUnit(proj.id, inp.dataset.unitWorth, { worth: parseFloat(e.target.value) || 0 });
       renderProjectionAnalysisBlock(body, appData.projections[proj.id]);
+    });
+  });
+  body.querySelectorAll('[data-unit-type]').forEach(sel => {
+    sel.addEventListener('change', e => {
+      updateProjectionUnit(proj.id, sel.dataset.unitType, { modelTypeId: e.target.value || null });
+      renderProjectionDetail(body, container, proj.id);
     });
   });
   body.querySelectorAll('[data-unit-delete]').forEach(btn => {


### PR DESCRIPTION
The importer's model-type detection is heuristic and sometimes wrong (e.g. a Doomwheel or Land Speeder defaulting to Infantry). Each projection unit row now has a Model Type dropdown instead of a static tag, so it can be corrected — hobby points and the cost-benefit analysis recalculate immediately from the new type's stages.