### PR TITLE
Add a 3-month pace window option to the pile burndown

### DIFF
--- a/index.html
+++ b/index.html
@@ -1034,8 +1034,8 @@
     .chart-wrap { height: 200px; position: relative; }
     .dash-chart-card { overflow: hidden; }
 
-    .pie-mode-toggle { display: flex; gap: 0.3em; flex-shrink: 0; }
-    .pie-mode-btn.active { background: var(--accent); border-color: var(--accent); color: #fff; }
+    .pie-mode-toggle, .chart-opt-toggle { display: flex; gap: 0.3em; flex-shrink: 0; }
+    .pie-mode-btn.active, .chart-opt-btn.active { background: var(--accent); border-color: var(--accent); color: #fff; }
 
     .dash-army-breakdown { grid-column: 1 / -1; }
     .army-pie-grid { display: flex; flex-wrap: wrap; gap: 1rem; }

--- a/js/charts.js
+++ b/js/charts.js
@@ -392,6 +392,46 @@ export function renderBurndown(canvasId, models, deadline) {
 // models would clear at the current rate.
 // ----------------------------------------------------------------
 
+// How far back the pile burndown measures pace. A month away from the desk
+// drags a 30-day window to zero and takes the projected clear date with it,
+// so the window is selectable and persisted alongside the other chart prefs.
+export const BURNDOWN_WINDOWS = [
+  { days: 30, label: '30 days', shortLabel: 'last 30 days' },
+  { days: 90, label: '3 months', shortLabel: 'last 3 months' }
+];
+
+export function getBurndownWindow() {
+  const days = appData.config.burndownWindowDays;
+  return BURNDOWN_WINDOWS.some(w => w.days === days) ? days : 30;
+}
+
+export function burndownWindowLabel(days = getBurndownWindow()) {
+  return (BURNDOWN_WINDOWS.find(w => w.days === days) || BURNDOWN_WINDOWS[0]).shortLabel;
+}
+
+export function burndownWindowToggleHtml() {
+  const current = getBurndownWindow();
+  return `
+    <div class="chart-opt-toggle">
+      ${BURNDOWN_WINDOWS.map(w => `
+        <button class="btn btn-xs chart-opt-btn ${w.days === current ? 'active' : ''}" data-burndown-window="${w.days}">${w.label}</button>
+      `).join('')}
+    </div>
+  `;
+}
+
+export function wireBurndownWindowToggle(container, onChange) {
+  container.querySelectorAll('[data-burndown-window]').forEach(btn => {
+    btn.addEventListener('click', () => {
+      const days = parseInt(btn.dataset.burndownWindow, 10);
+      if (getBurndownWindow() === days) return;
+      appData.config.burndownWindowDays = days;
+      saveData();
+      onChange();
+    });
+  });
+}
+
 // Trailing-window velocity + projected clear date, computed once and shared
 // by the chart and its text summary so they never disagree.
 //
@@ -408,7 +448,7 @@ export function renderBurndown(canvasId, models, deadline) {
 // a starting baseline of work already done, never as activity on that date, so
 // a big backfill can't masquerade as a burst of recent painting and inflate
 // the trailing-30-day velocity. Same rule the activity calendar already uses.
-export function pileBurndownStats() {
+export function pileBurndownStats(windowDays = getBurndownWindow()) {
   const sessionPoints = s => (s.modelEntries || []).reduce((acc, e) => {
     const model = appData.models[e.modelId];
     if (!model) return acc;
@@ -438,9 +478,17 @@ export function pileBurndownStats() {
 
   const sortedDates = Object.keys(byDay).sort();
   const todayStr = new Date().toISOString().split('T')[0];
-  const windowStart = new Date(Date.now() - 30 * 86400000).toISOString().split('T')[0];
+  const windowStart = new Date(Date.now() - windowDays * 86400000).toISOString().split('T')[0];
   const recentPts = sortedDates.filter(d => d >= windowStart).reduce((sum, d) => sum + byDay[d], 0);
-  const velocity = recentPts / 30;
+
+  // Never average over more history than exists: a 3-month window on three
+  // weeks of logs would report a third of the real pace. Floored at a week so
+  // a single day at the desk can't extrapolate into a fantasy rate.
+  const trackedDays = sortedDates.length
+    ? Math.floor((Date.parse(todayStr) - Date.parse(sortedDates[0])) / 86400000) + 1
+    : 0;
+  const effectiveDays = Math.min(windowDays, Math.max(7, trackedDays));
+  const velocity = recentPts / effectiveDays;
 
   let daysToClear = null, clearDate = null;
   if (velocity > 0 && pileRemainingPoints > 0) {
@@ -448,12 +496,13 @@ export function pileBurndownStats() {
     clearDate = new Date(Date.now() + daysToClear * 86400000).toISOString().split('T')[0];
   }
 
-  return { byDay, sortedDates, todayStr, pileRemainingPoints, velocity, daysToClear, clearDate, baselinePoints, historicalSessions };
+  return { byDay, sortedDates, todayStr, pileRemainingPoints, velocity, daysToClear, clearDate, baselinePoints, historicalSessions, windowDays, effectiveDays };
 }
 
 // Shared "how fast am I painting" rate (pts/day), used by both Sprint capacity
 // checks and Roadmap finish-date projections: your weekly goal if you've set
-// one, otherwise the trailing-30-day pace pileBurndownStats() already computes.
+// one, otherwise the trailing-window pace pileBurndownStats() already computes
+// (over whichever window the pile burndown is currently set to).
 // Pool-wide, not scoped per sprint/campaign — juggling several active sprints
 // or campaigns at once will double-count against this one shared rate.
 export function paceRate() {

--- a/js/dashboard.js
+++ b/js/dashboard.js
@@ -2,7 +2,7 @@
 
 import { appData, globalStats, listStats, saveData, GAME_SYSTEMS, modelThreshold, unstartedCount, singleModelPoints, getModelType, resolveModelGroup, MODEL_GROUP_ORDER, getModelDateAdded, resolveGameSystemId, greyBrigadeCount } from './data.js';
 import { progressBar, toast, daysUntil, formatDate, localDateStr } from './ui.js';
-import { renderCompositionPie, renderCompletionPie, renderBurndown, renderStageBar, renderListCompletionPie, pieModeToggleHtml, wirePieModeToggle, renderPileBurndown, pileBurndownStats } from './charts.js';
+import { renderCompositionPie, renderCompletionPie, renderBurndown, renderStageBar, renderListCompletionPie, pieModeToggleHtml, wirePieModeToggle, renderPileBurndown, pileBurndownStats, burndownWindowToggleHtml, wireBurndownWindowToggle, burndownWindowLabel } from './charts.js';
 import { showModal, closeModal, createDateInput, getDateValue } from './ui.js';
 import { renderBountySection, wireBountySection, renderHallOfFameSection, renderBadgesSection } from './badges.js';
 
@@ -149,6 +149,9 @@ export function renderDashboard() {
   // Pie chart weighting toggle (by model count or hobby points)
   wirePieModeToggle(container, () => renderDashboard());
 
+  // Pile burndown pace window (30 days / 3 months)
+  wireBurndownWindowToggle(container, () => renderDashboard());
+
   // Render pie charts
   requestAnimationFrame(() => {
     renderCompletionPie('completionPie');
@@ -164,25 +167,36 @@ export function renderDashboard() {
 // --- Pile burndown ---
 
 function pileBurndownSection() {
-  const { pileRemainingPoints, velocity, daysToClear, clearDate, baselinePoints, historicalSessions } = pileBurndownStats();
+  const { pileRemainingPoints, velocity, daysToClear, clearDate, baselinePoints, historicalSessions, windowDays, effectiveDays } = pileBurndownStats();
+  const windowLabel = burndownWindowLabel(windowDays);
   let summary;
   if (!pileRemainingPoints) {
     summary = `<p class="empty-text">Nothing left on the pile to burn down. Impressive!</p>`;
   } else if (!daysToClear) {
-    summary = `<p class="empty-text">${pileRemainingPoints} points remain on the pile — log some timed progress to start projecting a clear date.</p>`;
+    // A quiet spell can flatten the shorter window to zero — the longer one
+    // usually still has something to project from, so point at the toggle.
+    const tryWider = windowDays < 90 ? ` Been away from the desk for a while? Try the 3 month window.` : '';
+    summary = `<p class="empty-text">${pileRemainingPoints} points remain on the pile — no timed sessions in the ${windowLabel}, so there's no pace to project from.${tryWider}</p>`;
   } else {
-    summary = `<div class="pile-total">At ${velocity.toFixed(1)} pts/day (last 30 days), the pile clears in ~${daysToClear} days (${formatDate(clearDate, { month: 'short', day: 'numeric', year: 'numeric' })}).</div>`;
+    summary = `<div class="pile-total">At ${velocity.toFixed(1)} pts/day (${windowLabel}), the pile clears in ~${daysToClear} days (${formatDate(clearDate, { month: 'short', day: 'numeric', year: 'numeric' })}).</div>`;
   }
+  const notes = [];
   // Historical entries have no session time and no known date, so they set the
   // chart's starting level instead of counting towards the recent-pace figure.
-  const baselineNote = historicalSessions
-    ? `<div class="form-hint">${baselinePoints} pts from ${historicalSessions} historical ${historicalSessions === 1 ? 'entry' : 'entries'} counted as starting data, not recent activity.</div>`
-    : '';
+  if (historicalSessions) {
+    notes.push(`${baselinePoints} pts from ${historicalSessions} historical ${historicalSessions === 1 ? 'entry' : 'entries'} counted as starting data, not recent activity.`);
+  }
+  if (effectiveDays < windowDays) {
+    notes.push(`Pace averaged over ${effectiveDays} days — the full ${windowDays}-day window reaches back further than your session history.`);
+  }
   return `
     <div class="dash-card dash-chart-card dash-pile-burndown">
-      <h3>Pile Burndown</h3>
+      <div class="pile-card-header">
+        <h3>Pile Burndown</h3>
+        ${burndownWindowToggleHtml()}
+      </div>
       ${summary}
-      ${baselineNote}
+      ${notes.map(n => `<div class="form-hint">${n}</div>`).join('')}
       <div class="chart-wrap"><canvas id="pileBurndownChart"></canvas></div>
     </div>`;
 }

--- a/js/data.js
+++ b/js/data.js
@@ -616,6 +616,7 @@ export let appData = {
     weeklyGoal: 0,
     imageSize: 'small',
     pieChartMode: 'count',
+    burndownWindowDays: 30, // pile burndown pace window: 30 or 90 days
     monthlyBudgetGBP: 0,
     budgetPeriod: 'monthly', // 'monthly' | 'annual' — display/input preference; monthlyBudgetGBP stays the source of truth
     hobbyPointScale: HOBBY_POINT_SCALE, // stage-point scale this data is on; older values are lifted by migrateHobbyPointScale()
@@ -699,6 +700,7 @@ export function loadData() {
           weeklyGoal: parsed.config?.weeklyGoal || 0,
           imageSize: parsed.config?.imageSize || 'small',
           pieChartMode: parsed.config?.pieChartMode || 'count',
+          burndownWindowDays: parsed.config?.burndownWindowDays || 30,
           monthlyBudgetGBP: parsed.config?.monthlyBudgetGBP || 0,
           budgetPeriod: parsed.config?.budgetPeriod || 'monthly',
           hobbyPointScale: parsed.config?.hobbyPointScale || 1,
@@ -755,6 +757,7 @@ export function replaceData(parsed) {
       weeklyGoal: parsed.config?.weeklyGoal || 0,
       imageSize: parsed.config?.imageSize || 'small',
       pieChartMode: parsed.config?.pieChartMode || 'count',
+      burndownWindowDays: parsed.config?.burndownWindowDays || 30,
       monthlyBudgetGBP: parsed.config?.monthlyBudgetGBP || 0,
       budgetPeriod: parsed.config?.budgetPeriod || 'monthly',
       hobbyPointScale: parsed.config?.hobbyPointScale || 1


### PR DESCRIPTION
A month away from the desk empties the trailing 30-day window, so velocity falls to zero and the projected clear date disappears entirely — exactly when a longer view would still have plenty to project from.

The pace window is now selectable (30 days / 3 months) from a toggle in the Pile Burndown card header, persisted in config.burndownWindowDays alongside the other chart preferences. When the shorter window comes up empty the summary says so and points at the wider one instead of just asking for more logging.

The window also feeds paceRate(), so sprint capacity checks and roadmap finish dates pick up the same choice.

Velocity is no longer divided by the full window when there isn't that much history: it averages over the logged span instead (floored at a week), so a 3-month window on three weeks of sessions reports the real pace rather than a third of it. The card notes when that applies.

The cumulative chart line still shows all history — the window governs the pace figure and the projection, not what's plotted.


Claude-Session: https://claude.ai/code/session_013C4mrfCqyhPZRrqtV8Si6S