### PR TITLE
Render Quartermaster's Office as a page instead of a modal

### DIFF
--- a/index.html
+++ b/index.html
@@ -328,6 +328,12 @@
       align-items: center;
     }
 
+    .header-actions .btn.active {
+      background: var(--accent);
+      border-color: var(--accent);
+      color: #fff;
+    }
+
     .tips-btn { position: relative; }
     .tips-dot {
       position: absolute;
@@ -2360,6 +2366,14 @@
       <div id="activityView"></div>
     </div>
 
+    <!-- Quartermaster's Office (reached from the header button, not the tab bar) -->
+    <div class="tab-panel" id="tab-quartermaster">
+      <div class="panel-header">
+        <h2>🎖️ Quartermaster's Office</h2>
+      </div>
+      <div id="qmView"></div>
+    </div>
+
     <!-- Settings (modal, not a tab) -->
     <div id="settingsModal" style="display:none"></div>
 
@@ -2422,6 +2436,10 @@
     if (tabId === 'roadmap') renderRoadmap();
     if (tabId === 'sprints') renderSprints();
     if (tabId === 'activity') renderActivity();
+    if (tabId === 'quartermaster') renderQuartermaster(document.getElementById('qmView'));
+    // The office has no nav tab of its own, so its header button doubles as
+    // the "you are here" indicator.
+    document.getElementById('quartermasterBtn').classList.toggle('active', tabId === 'quartermaster');
     refreshTipsBadge();
   }
 
@@ -2439,7 +2457,8 @@
     showModal({ title: '⚙️ Settings', content, wide: false });
     renderSettings(content);
   });
-  // --- Quartermaster's Office (modal, not a tab — always reminds before entering) ---
+  // --- Quartermaster's Office (a full page panel reached from the header,
+  // not the tab bar — always reminds before entering) ---
   document.getElementById('quartermasterBtn').addEventListener('click', () => {
     const count = pileCount();
     const worth = pileWorth();
@@ -2448,12 +2467,7 @@
       message: `You currently have <b>${count}</b> model${count !== 1 ? 's' : ''} on the pile, worth <b>£${worth.toFixed(0)}</b>.` +
         (rect === null ? '' : ` Rectitude: <b>${Math.round(rect)}%</b>.`),
       confirmLabel: 'Enter',
-      onConfirm: () => {
-        const content = document.createElement('div');
-        content.id = 'qmView';
-        showModal({ title: "🎖️ Quartermaster's Office", content, wide: true });
-        renderQuartermaster(content);
-      }
+      onConfirm: () => switchTab('quartermaster')
     });
   });
 

--- a/js/quartermaster.js
+++ b/js/quartermaster.js
@@ -899,10 +899,9 @@ function requisitionCard(item) {
   `;
 }
 
-// Add/edit form for a requisition, rendered inline in the office body (NOT
-// a nested showModal — this app's modal system only tracks one overlay at a
-// time, so opening a second modal on top of the office would silently close
-// it). Shows a live "what would promoting this do to the pile / rectitude"
+// Add/edit form for a requisition, rendered inline in the office body rather
+// than in a modal — the office is a full page, so its forms stay on that page.
+// Shows a live "what would promoting this do to the pile / rectitude"
 // preview as the worth field changes — nothing is written to appData until Save.
 function renderRequisitionForm(body, container, editId) {
   const item = editId ? appData.purchaseQueue[editId] : null;
@@ -1662,9 +1661,8 @@ function autoDetectProjectionFormat(text) {
   return null;
 }
 
-// Rendered inline in the office body, not a nested showModal — the office
-// itself is already inside one modal, and this app's modal system only
-// tracks a single overlay at a time.
+// Rendered inline in the office body rather than in a modal, matching the
+// rest of the office's forms.
 function renderProjectionImportForm(body, container) {
   let currentFormat = 'owb';
 
@@ -1752,7 +1750,7 @@ function renderProjectionImportForm(body, container) {
 }
 
 // Shares via the OS share sheet or clipboard where available; the fallback
-// is an inline read-only view (not a nested showModal — see note above).
+// is an inline read-only view in the office body (see note above).
 function shareProjection(body, container, proj) {
   const text = buildProjectionShareText(proj);
   if (navigator.share) {


### PR DESCRIPTION
The office was opened via showModal, so it appeared in a cramped, windowed
overlay despite being a full multi-section view. It now renders into its own
tab-panel, reached from the header button (it deliberately stays off the tab
bar so the pile reminder always fires first). The header button gets an
active state to act as the 'you are here' indicator, since there is no nav
tab to highlight.

Also refreshed the comments in quartermaster.js that justified inline forms
by the single-overlay modal limitation, which no longer applies.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01C269Q88GnNXM7p2ce3nPmS