### PR TITLE
Add tips for the Quartermaster, gamification and pace features

### DIFF
--- a/js/tips.js
+++ b/js/tips.js
@@ -3,7 +3,9 @@
 // unused (or a situation where it would help) so people who already lean on
 // a feature stop getting nagged about it — the tip simply stops matching.
 
-import { appData, saveData, getAllModels, getAllModelTypes, modelThreshold, GAME_SYSTEMS, getRoadmapLists, getCampaignSprints } from './data.js';
+import { appData, saveData, getAllModels, getAllModelTypes, modelThreshold, GAME_SYSTEMS, getRoadmapLists, getCampaignSprints, getModelDateAdded, resolveGameSystemId, unstartedCount, greyBrigadeCount } from './data.js';
+import { BADGES, oldestPileModel } from './badges.js';
+import { getBurndownWindow } from './charts.js';
 import { isConfigured, wasConnected } from './gdrive.js';
 import { showModal, today } from './ui.js';
 
@@ -106,6 +108,60 @@ const TIP_DEFINITIONS = [
     text: "Turn a Roadmap campaign's remaining work into a Sprint — hit \"Plan Sprint\" on its card for a batch sized to your pace and dated toward its deadline.",
     condition: ctx => ctx.campaignNeedsSprintPlan
   },
+  {
+    id: 'bounty',
+    icon: '🎯',
+    text: "Something has been sitting on the sprue a very long time — put a Bounty on it from the Dashboard, name your own reward, and collect when it's finished.",
+    condition: ctx => !ctx.hasBounty && ctx.hallOfFameCount === 0 && ctx.oldestPileAgeDays >= 90
+  },
+  {
+    id: 'badges',
+    icon: '🏅',
+    text: `There are ${BADGES.length} badges waiting on the Dashboard — First Blood for your first finished model, Sprue Slayer for clearing the Grey Brigade, and more. They unlock on their own as you paint.`,
+    condition: ctx => ctx.badgeCount === 0 && ctx.hasAnyProgress
+  },
+  {
+    id: 'wishlist',
+    icon: '🌟',
+    text: "Requisitions filling up with things you haven't picked a month for? Park them on the Wishlist tab instead — no month, no budget commitment — then \"Move to Requisitions\" when you're ready to plan one.",
+    condition: ctx => ctx.wishlistCount === 0 && ctx.unplannedQueueCount >= 3
+  },
+  {
+    id: 'projections',
+    icon: '🔮',
+    text: "Tempted by a whole new army? Import the list into the Projections tab (Quartermaster's Office) to tick off what you already own, price the rest, and get a buy/skip verdict before you spend a penny.",
+    condition: ctx => ctx.projectionCount === 0 && (ctx.purchaseQueueCount >= 1 || ctx.wishlistCount >= 1)
+  },
+  {
+    id: 'projection_bundles',
+    icon: '📦',
+    text: "Picking up part of a projection as a box deal? Bundle those units together on it — the box price replaces their individual costs in the verdict, and the working shows what the deal saves you.",
+    condition: ctx => ctx.projectionNeedsBundle
+  },
+  {
+    id: 'projection_system',
+    icon: '🛡️',
+    text: "Set a game system on a projection so it's judged against that system's own backlog and prices — without one, every system's pile is lumped into the verdict together.",
+    condition: ctx => ctx.systemlessProjectionCount > 0 && ctx.pileSystemCount > 1
+  },
+  {
+    id: 'model_worth',
+    icon: '💷',
+    text: "Fill in Worth (£) on a model's entry — priced models are what the Quartermaster's Office weighs the pile against, and they set the £-per-hobby-point benchmark that Projections score value on.",
+    condition: ctx => ctx.pricedModelCount === 0 && ctx.modelCount >= 8
+  },
+  {
+    id: 'burndown_window',
+    icon: '📉',
+    text: "A quiet month at the desk drags a 30-day pace reading toward zero — switch the pile burndown to its 3-month window on the Dashboard for a steadier estimate.",
+    condition: ctx => ctx.burndownWindowDays !== 90 && ctx.quarterSessionCount >= 4 && ctx.recentSessionCount <= 1
+  },
+  {
+    id: 'historical_activity',
+    icon: '🕰️',
+    text: "Backfilling models you painted before you started tracking? Leave the session time blank — historical entries count as a starting baseline rather than recent activity, so a big catch-up won't inflate your pace.",
+    condition: ctx => ctx.historicalSessionCount === 0 && ctx.sessionCount >= 3 && ctx.modelCount >= 10
+  },
 ];
 
 function buildContext() {
@@ -140,6 +196,47 @@ function buildContext() {
     return hasUnfinished && getCampaignSprints(l).length === 0;
   });
 
+  // --- Quartermaster: wishlist, requisitions, projections ---
+  const wishlistCount = Object.keys(appData.wishlist || {}).length;
+  const queued = Object.values(appData.purchaseQueue || {}).filter(i => i.status !== 'purchased');
+  // Queued requisitions with no month against them are really wishes that
+  // ended up in the planning queue — exactly what the Wishlist tab is for.
+  const unplannedQueueCount = queued.filter(i => !i.plannedMonth).length;
+  const projections = Object.values(appData.projections || {});
+  // A projection with several unowned units and no bundles is the case box
+  // deals exist for — one price for the set instead of unit by unit.
+  const projectionNeedsBundle = projections.some(p =>
+    (p.units || []).filter(u => !u.owned).length >= 3 && (p.bundles || []).length === 0
+  );
+  const systemlessProjectionCount = projections.filter(p => !p.gameSystemId).length;
+  // How many game systems the pile spans — an unscoped projection is only
+  // misleading once there's more than one backlog being averaged together.
+  const pileSystemCount = new Set(
+    models
+      .filter(m => unstartedCount(m) > 0 || greyBrigadeCount(m) > 0)
+      .map(m => resolveGameSystemId(m))
+      .filter(Boolean)
+  ).size;
+  const pricedModelCount = models.filter(m => m.worth > 0).length;
+
+  // --- Gamification ---
+  const oldestOnPile = oldestPileModel();
+  const oldestAdded = oldestOnPile ? getModelDateAdded(oldestOnPile) : null;
+  const oldestPileAgeDays = oldestAdded
+    ? Math.floor((Date.now() - oldestAdded.getTime()) / 86400000)
+    : 0;
+
+  // --- Activity pace ---
+  const sessions = appData.sessions || [];
+  // Historical entries carry no duration: backfilled work with no real date,
+  // which the burndown treats as baseline rather than recent activity.
+  const historicalSessionCount = sessions.filter(s => !s.duration).length;
+  const datedSessions = sessions.filter(s => s.duration && s.date);
+  const daysAgo = n => new Date(Date.now() - n * 86400000).toISOString().slice(0, 10);
+  const last30 = daysAgo(30), last90 = daysAgo(90);
+  const recentSessionCount = datedSessions.filter(s => s.date >= last30).length;
+  const quarterSessionCount = datedSessions.filter(s => s.date >= last90).length;
+
   return {
     modelCount: models.length,
     folderCount: Object.keys(folders).length,
@@ -159,6 +256,21 @@ function buildContext() {
     nonCustomCollectionCount,
     roadmapListCount,
     campaignNeedsSprintPlan,
+    wishlistCount,
+    unplannedQueueCount,
+    projectionCount: projections.length,
+    projectionNeedsBundle,
+    systemlessProjectionCount,
+    pileSystemCount,
+    pricedModelCount,
+    hasBounty: !!appData.bounty,
+    hallOfFameCount: (appData.hallOfFame || []).length,
+    badgeCount: Object.keys(appData.badges || {}).length,
+    oldestPileAgeDays,
+    historicalSessionCount,
+    recentSessionCount,
+    quarterSessionCount,
+    burndownWindowDays: getBurndownWindow(),
   };
 }
 


### PR DESCRIPTION
The tip list hadn't been touched since the Sprints/Roadmap round, so
everything added after it — the Bounty Board, badges, the Wishlist and
Projections tabs, model pricing and the pile burndown's pace window —
had no hint pointing at it.

Nine new tips, each conditioned on the feature going unused the same way
the existing ones are, so they stop matching once someone picks the
feature up:

- bounty / badges: the Dashboard's gamification, once something has sat
  on the sprue 90+ days or the first badge is still unearned
- wishlist: when queued requisitions have piled up with no month set
- projections / projection_bundles / projection_system: evaluating an
  army before buying it, box deals, and scoping a projection to a system
  when the pile spans several
- model_worth: pricing models, which drives rectitude and the
  £-per-hobby-point benchmark Projections score against
- burndown_window / historical_activity: reading pace honestly after a
  quiet month or a backfill

buildContext() grows the matching counters: wishlist and unplanned
requisitions, projection shape, priced models, pile age for the bounty,
and the session split behind the pace tips.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01WAtxBaq9X4vNtPafn6psDq