### PR TITLE
Add mothballing: shelve models you'll never get round to

### DIFF
--- a/index.html
+++ b/index.html
@@ -863,6 +863,13 @@
     .list-models-header { display: flex; justify-content: space-between; align-items: center; margin-bottom: 0.6em; }
     .list-models-header h3 { font-family: var(--font-display); font-size: 0.95em; }
 
+    .list-model-row-mothballed {
+      opacity: 0.62;
+      filter: saturate(0.35);
+      border-style: dashed;
+    }
+    .list-model-inert { font-size: 0.75em; color: var(--text-muted); font-style: italic; }
+
     .list-model-row {
       display: flex;
       align-items: center;
@@ -1077,6 +1084,14 @@
     .qm-rect-figure { font-size: 1.8em; font-weight: 700; font-family: var(--font-display); }
     .qm-rect-positive { color: var(--accent); }
     .qm-rect-negative { color: var(--danger); }
+    .pile-mothball-note {
+      font-size: 0.78em;
+      color: var(--text-muted);
+      margin-top: 0.75em;
+      padding-top: 0.6em;
+      border-top: 1px dashed var(--border);
+    }
+
     .pile-shame-badge { display: inline-block; font-size: 0.7em; padding: 0.1em 0.45em; border-radius: 3px; margin-left: 0.5em; font-family: var(--font-ui); white-space: nowrap; vertical-align: middle; }
     .shame-fresh { background: color-mix(in srgb, var(--text-muted) 20%, transparent); color: var(--text-muted); }
     .shame-dusty { background: color-mix(in srgb, var(--warning) 25%, transparent); color: var(--warning); }
@@ -1857,6 +1872,21 @@
       background: color-mix(in srgb, var(--accent) 6%, var(--surface));
     }
 
+    .queue-entry-mothballed {
+      opacity: 0.62;
+      filter: saturate(0.35);
+      border-style: dashed;
+      border-color: var(--border) !important;
+      background: var(--surface);
+    }
+
+    .queue-entry-inert {
+      font-size: 0.78em;
+      color: var(--text-muted);
+      font-style: italic;
+      align-self: center;
+    }
+
     .queue-up-next-label {
       font-size: 0.75em;
       font-weight: 700;
@@ -1992,6 +2022,34 @@
     }
 
     .folder-actions { display: flex; gap: 0.3em; align-items: center; }
+
+    /* Mothballed shelf — deliberately muted, it isn't working stock */
+    .folder-mothballed { opacity: 0.9; }
+    .folder-mothballed .folder-header { background: var(--bg2); }
+    .folder-mothballed .folder-name { color: var(--text-muted); }
+    .mothball-note {
+      font-size: 0.8em;
+      color: var(--text-muted);
+      line-height: 1.5;
+      margin-bottom: 0.75em;
+    }
+    .model-card-mothballed {
+      opacity: 0.62;
+      filter: saturate(0.35);
+      border-style: dashed;
+    }
+    .model-card-mothballed:hover { opacity: 0.85; }
+    .mothball-badge {
+      display: inline-block;
+      font-size: 0.7em;
+      padding: 0.15em 0.5em;
+      border-radius: 3px;
+      font-family: var(--font-ui);
+      white-space: nowrap;
+      background: var(--bg2);
+      border: 1px solid var(--border);
+      color: var(--text-muted);
+    }
     .folder-models { padding: 0.75em; background: var(--bg); }
     .folder-empty { font-size: 0.85em; color: var(--text-muted); font-style: italic; padding: 0.25em 0; }
     .folder-unfiled .folder-header { background: var(--bg2); }

--- a/js/badges.js
+++ b/js/badges.js
@@ -5,7 +5,7 @@
 // holds you to it and makes the payoff feel like an event when it lands.
 
 import {
-  appData, saveData, uid, globalStats, getAllModels, unstartedCount, modelThreshold,
+  appData, saveData, uid, globalStats, getActiveModels, unstartedCount, modelThreshold,
   modelPoints, greyBrigadeCount, getModelDateAdded,
   setBounty, clearBounty, addHallOfFameEntry, recordBadgeEarned
 } from './data.js';
@@ -34,7 +34,7 @@ export const BADGES = [
     name: 'Zero Shame',
     desc: 'Empty the Pile of Potential — nothing left on the sprue.',
     check: () => {
-      const models = getAllModels();
+      const models = getActiveModels();
       return models.length > 0 && models.every(m => unstartedCount(m) === 0);
     }
   },
@@ -44,7 +44,7 @@ export const BADGES = [
     name: 'Sprue Slayer',
     desc: 'Clear the Grey Brigade — nothing left assembled-but-unpainted.',
     check: () => {
-      const models = getAllModels();
+      const models = getActiveModels();
       const anyEverAssembled = models.some(m => modelThreshold(m) !== 'not_started');
       return anyEverAssembled && models.every(m => greyBrigadeCount(m) === 0);
     }
@@ -80,7 +80,7 @@ function bountyTier(ageDays) {
 
 // The oldest model still sitting on the sprue — the default bounty target.
 export function oldestPileModel() {
-  const candidates = getAllModels()
+  const candidates = getActiveModels()
     .map(m => ({ model: m, added: getModelDateAdded(m) }))
     .filter(e => unstartedCount(e.model) > 0);
   if (!candidates.length) return null;

--- a/js/charts.js
+++ b/js/charts.js
@@ -1,6 +1,6 @@
 // charts.js — all Chart.js rendering
 
-import { appData, GAME_SYSTEMS, modelPoints, modelThresholdBreakdown, stageCap, saveData, unstartedCount } from './data.js';
+import { appData, GAME_SYSTEMS, modelPoints, modelThresholdBreakdown, stageCap, saveData, unstartedCount, getActiveModels } from './data.js';
 import { localDateStr } from './ui.js';
 
 // Track chart instances so we can destroy before re-creating
@@ -84,8 +84,9 @@ export function renderCompositionPie(canvasId) {
     });
   });
 
-  // Weight (model count or hobby points) per system it belongs to
-  Object.values(appData.models).forEach(m => {
+  // Weight (model count or hobby points) per system it belongs to.
+  // Mothballed models are out of the picture entirely.
+  getActiveModels().forEach(m => {
     const systems = modelSystems[m.id];
     const weight = modelWeight(m, mode);
     if (!systems || systems.size === 0) {
@@ -150,7 +151,7 @@ export function renderCompletionPie(canvasId) {
   const unit = mode === 'points' ? 'pts' : 'models';
   let finished = 0, painted = 0, tableReady = 0, inProgress = 0, notStarted = 0;
 
-  Object.values(appData.models).forEach(m => {
+  getActiveModels().forEach(m => {
     const b = modelThresholdBreakdown(m);
     finished   += tierWeight(m, b.finished, mode);
     painted    += tierWeight(m, b.painted, mode);

--- a/js/collections.js
+++ b/js/collections.js
@@ -5,7 +5,7 @@ import {
   createList, deleteList, addModelToList, removeModelFromList,
   setModelSplits, removeModelSplits, splitModelPoints, splitModelThreshold,
   listStats, saveData, uid, GAME_SYSTEMS, modelPoints, modelThreshold,
-  addListToRoadmap, removeListFromRoadmap
+  addListToRoadmap, removeListFromRoadmap, isMothballed
 } from './data.js';
 import { showModal, closeModal, showConfirm, toast, progressBar, thresholdBadge, createDateInput, getDateValue, formatDate, fireworks } from './ui.js';
 import { applyTheme, resetTheme, setCurrentSystem, resetCurrentSystem, getTerm } from './theme.js';
@@ -335,19 +335,22 @@ function listModelRow(model, listId) {
 
   const pts = modelPoints(model);
   const thresh = modelThreshold(model);
+  // A mothballed model stays listed (removing it is the user's call) but is
+  // inert: no logging, and listStats() leaves it out of the list totals.
+  const mothballed = isMothballed(model);
   return `
-    <div class="list-model-row" data-model-view="${model.id}">
+    <div class="list-model-row${mothballed ? ' list-model-row-mothballed' : ''}" data-model-view="${model.id}">
       <div class="list-model-info">
-        <div class="list-model-name">${model.name}</div>
+        <div class="list-model-name">${model.name}${mothballed ? ' <span class="mothball-badge">🧊 Mothballed</span>' : ''}</div>
         <div class="list-model-qty">×${model.quantity}</div>
       </div>
       <div class="list-model-prog">
         <div class="prog-bar"><div class="prog-fill" style="width:${pts.pct}%"></div></div>
-        <span class="list-model-thresh">${thresholdBadge(thresh)}</span>
+        <span class="list-model-thresh">${mothballed ? '<span class="list-model-inert">not counted</span>' : thresholdBadge(thresh)}</span>
       </div>
       <div class="list-model-actions">
         <button class="btn btn-sm" data-model-split="${model.id}" title="Split unit">✂️</button>
-        <button class="btn btn-sm btn-primary" data-model-log="${model.id}">📝</button>
+        ${mothballed ? '' : `<button class="btn btn-sm btn-primary" data-model-log="${model.id}">📝</button>`}
         <button class="btn btn-sm btn-danger" data-model-remove="${model.id}">✕</button>
       </div>
     </div>
@@ -379,13 +382,13 @@ function listModelRowSplit(model, listId, splits) {
   }).join('');
 
   return `
-    <div class="list-model-split-group">
+    <div class="list-model-split-group${isMothballed(model) ? ' list-model-row-mothballed' : ''}">
       <div class="split-group-header">
-        <span class="split-group-name">${model.name}</span>
+        <span class="split-group-name">${model.name}${isMothballed(model) ? ' <span class="mothball-badge">🧊 Mothballed</span>' : ''}</span>
         <span class="split-group-meta">✂️ split · pool: ×${model.quantity}</span>
         <div class="list-model-actions" style="margin-left:auto">
           <button class="btn btn-sm" data-model-split="${model.id}" title="Edit split">✂️ Edit</button>
-          <button class="btn btn-sm btn-primary" data-model-log="${model.id}">📝</button>
+          ${isMothballed(model) ? '' : `<button class="btn btn-sm btn-primary" data-model-log="${model.id}">📝</button>`}
           <button class="btn btn-sm btn-danger" data-model-remove="${model.id}">✕</button>
         </div>
       </div>
@@ -513,6 +516,7 @@ function showAddModelToList(listId) {
 
   const renderPicker = (filter = '', folderId = '') => {
     const filtered = allModels.filter(m => {
+      if (isMothballed(m) && !already.includes(m.id)) return false;
       const matchName = m.name.toLowerCase().includes(filter.toLowerCase());
       const matchFolder = !folderId || m.folderId === folderId;
       return matchName && matchFolder;

--- a/js/dashboard.js
+++ b/js/dashboard.js
@@ -1,6 +1,6 @@
 // dashboard.js — dashboard with pie charts and deadline cards
 
-import { appData, globalStats, listStats, saveData, GAME_SYSTEMS, modelThreshold, unstartedCount, singleModelPoints, getModelType, resolveModelGroup, MODEL_GROUP_ORDER, getModelDateAdded, resolveGameSystemId, greyBrigadeCount } from './data.js';
+import { appData, globalStats, listStats, saveData, GAME_SYSTEMS, modelThreshold, unstartedCount, singleModelPoints, getModelType, resolveModelGroup, MODEL_GROUP_ORDER, getModelDateAdded, resolveGameSystemId, greyBrigadeCount, getActiveModels, getMothballedModels } from './data.js';
 import { progressBar, toast, daysUntil, formatDate, localDateStr } from './ui.js';
 import { renderCompositionPie, renderCompletionPie, renderBurndown, renderStageBar, renderListCompletionPie, pieModeToggleHtml, wirePieModeToggle, renderPileBurndown, pileBurndownStats, burndownWindowToggleHtml, wireBurndownWindowToggle, burndownWindowLabel } from './charts.js';
 import { showModal, closeModal, createDateInput, getDateValue } from './ui.js';
@@ -553,7 +553,7 @@ const GROUP_CLASS = {
 // batch total), so a Dragon-sized entry dwarfs an Ogre, which in turn dwarfs
 // a rank-and-file infantry model — regardless of how many are in the unit.
 function modelPointsRange() {
-  const totals = Object.values(appData.models).map(m => singleModelPoints(m) || 1);
+  const totals = getActiveModels().map(m => singleModelPoints(m) || 1);
   if (!totals.length) return { min: 1, max: 1 };
   return { min: Math.min(...totals), max: Math.max(...totals) };
 }
@@ -625,6 +625,15 @@ function wirePictoFigs(container) {
   });
 }
 
+// Mothballed models are absent from the pile by design — say so, so a model
+// you shelved doesn't just silently vanish from the count.
+function mothballFootnote() {
+  const shelved = getMothballedModels();
+  if (!shelved.length) return '';
+  const count = shelved.reduce((sum, m) => sum + m.quantity, 0);
+  return `<p class="pile-mothball-note">🧊 ${count} model${count !== 1 ? 's' : ''} mothballed and not counted here — see the Pool tab to bring ${count !== 1 ? 'them' : 'it'} back.</p>`;
+}
+
 function pileOfPotentialSection() {
   const withUnstarted = Object.values(appData.models)
     .map(m => ({ model: m, unstarted: unstartedCount(m) }))
@@ -689,6 +698,7 @@ function pileOfPotentialSection() {
           ${pictoLegendHtml(withUnstarted)}
         `
       }
+      ${mothballFootnote()}
     </div>`;
 }
 

--- a/js/data.js
+++ b/js/data.js
@@ -796,6 +796,8 @@ export function createModel({ name, quantity = 1, notes = '', gameSystemId = nul
     sentimentLove,
     purchaseDate,
     resaleValue,
+    mothballed: false,
+    mothballedDate: null,
     dateAdded: new Date().toISOString().slice(0, 10),
     progress: {},
     sessions: []
@@ -828,9 +830,40 @@ export function deleteModel(id) {
   saveData();
 }
 
+// --- Mothballing ---
+// A mothballed model is one you have no intention of working on — for now, or
+// maybe ever. It stays in the collection (and in any army list or sprint it
+// already belonged to) but goes inert: no progress can be logged against it,
+// and it drops out of every hobby stat — the pile, the Grey Brigade,
+// rectitude, completion percentages. Nothing is destroyed while it sleeps,
+// so unmothballing brings it back with its progress exactly as it was.
+
+export function isMothballed(model) {
+  return !!model?.mothballed;
+}
+
+export function getActiveModels() {
+  return getAllModels().filter(m => !m.mothballed);
+}
+
+export function getMothballedModels() {
+  return getAllModels().filter(m => m.mothballed);
+}
+
+export function setModelMothballed(id, mothballed) {
+  const model = appData.models[id];
+  if (!model) return;
+  model.mothballed = !!mothballed;
+  model.mothballedDate = mothballed ? new Date().toISOString().slice(0, 10) : null;
+  saveData();
+}
+
 export function logProgress(modelId, stageId, done, date) {
   const model = appData.models[modelId];
   if (!model) return;
+  // Mothballed models are deactivated — guarded here so no caller can put
+  // work against something the user has explicitly shelved.
+  if (model.mothballed) return;
   const stage = (model.stages || appData.config.stages).find(s => s.id === stageId);
   const cap = stageCap(stage, model);
   if (!model.progress[stageId]) model.progress[stageId] = { done: 0, lastDate: null };
@@ -870,6 +903,9 @@ export function modelThreshold(model) {
 }
 
 export function unstartedCount(model) {
+  // Mothballed models contribute nothing to the pile — zeroing it here is what
+  // keeps them out of pileCount/pileWorth (and so out of rectitude) everywhere.
+  if (model.mothballed) return 0;
   const stages = model.stages || appData.config.stages;
   const skipped = model.skippedStages || [];
   const activeStages = stages.filter(s => !skipped.includes(s.id));
@@ -915,6 +951,8 @@ export function resolveGameSystemId(model) {
 // multi-part entries (hull + crew) don't map onto it, so skip them rather
 // than report bogus counts.
 export function greyBrigadeCount(model) {
+  // Same as unstartedCount: a shelved model isn't languishing, it's parked.
+  if (model.mothballed) return 0;
   const stages = model.stages || appData.config.stages;
   const skipped = model.skippedStages || [];
 
@@ -1048,8 +1086,10 @@ export function listStats(list) {
   let tableReady = 0, painted = 0, finished = 0, total = 0;
 
   (list.modelIds || []).forEach(id => {
+    // A mothballed model stays in the list but leaves its totals — otherwise
+    // shelving one would leave the list permanently short of 100%.
     const m = appData.models[id];
-    if (!m) return;
+    if (!m || m.mothballed) return;
     const splits = modelSplits[id];
     if (splits && splits.length > 0) {
       let offset = 0;
@@ -1085,8 +1125,10 @@ export function listStats(list) {
   };
 }
 
+// Collection-wide totals. Mothballed models are excluded: shelving something
+// you'll never paint shouldn't go on dragging your completion down forever.
 export function globalStats() {
-  const models = getAllModels();
+  const models = getActiveModels();
   let totalPts = 0, donePts = 0;
   let tableReady = 0, painted = 0, finished = 0, total = 0;
 

--- a/js/models.js
+++ b/js/models.js
@@ -5,15 +5,18 @@ import {
   logProgress, logSession, modelPoints, modelThreshold, stageCap, uid, saveData,
   getAllModelTypes, saveCustomModelType, deleteCustomModelType,
   saveModelTypeOverride, resetModelTypeOverride, BUILTIN_MODEL_TYPES, TYPE_GROUPS,
-  createFolder, updateFolder, deleteFolder, getAllFolders
+  createFolder, updateFolder, deleteFolder, getAllFolders,
+  isMothballed, setModelMothballed
 } from './data.js';
-import { showModal, closeModal, toast, progressBar, thresholdBadge, stageRow, today, createDateInput, getDateValue, createTimeInput } from './ui.js';
+import { showModal, closeModal, toast, progressBar, thresholdBadge, stageRow, today, createDateInput, getDateValue, createTimeInput, formatDate } from './ui.js';
 import { getTerm } from './theme.js';
 import { compressImageToBase64, IMAGE_SIZE_PRESETS } from './imageUtils.js';
 
-// Select mode state for mass move
+// Select mode state for mass move / mass mothball
 let _selectMode = false;
 let _selectedIds = new Set();
+// The mothballed shelf starts collapsed — it's deliberately out of the way.
+let _mothballCollapsed = true;
 
 // Lazy import to avoid circular dependency
 async function pruneSprints() {
@@ -29,10 +32,14 @@ export function renderModelPool(containerId = 'modelPool') {
   const container = document.getElementById(containerId);
   if (!container) return;
 
-  const allModels = Object.values(appData.models);
+  const everyModel = Object.values(appData.models);
+  // Mothballed models are shelved together at the bottom rather than sitting
+  // in their folders — they're not part of the working collection any more.
+  const allModels = everyModel.filter(m => !isMothballed(m));
+  const mothballed = everyModel.filter(m => isMothballed(m));
   const folders = getAllFolders();
 
-  if (!allModels.length && !folders.length) {
+  if (!everyModel.length && !folders.length) {
     container.innerHTML = `
       <div class="onboarding-card">
         <div class="onboarding-title">👋 Welcome to Hobby Manager!</div>
@@ -128,7 +135,15 @@ export function renderModelPool(containerId = 'modelPool') {
   }
 
   if (!html) {
-    html = `<div class="empty-state"><p>No models yet. Use the + button to add one.</p></div>`;
+    html = mothballed.length
+      ? `<div class="empty-state"><p>Everything you own is mothballed. Bring something back below to start working on it again.</p></div>`
+      : `<div class="empty-state"><p>No models yet. Use the + button to add one.</p></div>`;
+  }
+
+  // Mothballed shelf — hidden entirely while selecting, since select mode
+  // only ever acts on the working collection.
+  if (mothballed.length && !_selectMode) {
+    html += mothballShelfHtml(mothballed);
   }
 
   if (!hasLists) {
@@ -163,6 +178,7 @@ export function renderModelPool(containerId = 'modelPool') {
             ${folders.map(f => `<option value="${f.id}">${f.name}</option>`).join('')}
           </select>
           <button class="btn btn-sm btn-primary" id="massMoveApply">Move</button>
+          <button class="btn btn-sm" id="massMothballApply" title="Shelve the selected models — they stop counting toward anything">🧊 Mothball</button>
         </div>
       ` : ''}
     `;
@@ -200,6 +216,16 @@ export function renderModelPool(containerId = 'modelPool') {
     _selectedIds.clear();
     const dest = folderId ? (appData.folders[folderId]?.name || 'folder') : 'Unfiled';
     toast(`Moved ${count} model${count !== 1 ? 's' : ''} to ${dest}`, 'success');
+    renderModelPool(containerId);
+  });
+
+  container.querySelector('#massMothballApply')?.addEventListener('click', () => {
+    const count = _selectedIds.size;
+    if (!confirm(`Mothball ${count} model${count !== 1 ? 's' : ''}? They stop counting toward your pile, Grey Brigade and rectitude until you bring them back.`)) return;
+    _selectedIds.forEach(id => setModelMothballed(id, true));
+    _selectMode = false;
+    _selectedIds.clear();
+    toast(`🧊 Mothballed ${count} model${count !== 1 ? 's' : ''}`, 'info');
     renderModelPool(containerId);
   });
 
@@ -269,6 +295,64 @@ export function renderModelPool(containerId = 'modelPool') {
   container.querySelectorAll('[data-model-log]').forEach(el => {
     el.addEventListener('click', e => { e.stopPropagation(); showLogProgress(el.dataset.modelLog); });
   });
+  container.querySelectorAll('[data-model-mothball]').forEach(el => {
+    el.addEventListener('click', e => { e.stopPropagation(); confirmMothball(el.dataset.modelMothball); });
+  });
+  container.querySelectorAll('[data-model-unmothball]').forEach(el => {
+    el.addEventListener('click', e => { e.stopPropagation(); unmothballModel(el.dataset.modelUnmothball); });
+  });
+  container.querySelector('#mothballToggle')?.addEventListener('click', () => {
+    _mothballCollapsed = !_mothballCollapsed;
+    renderModelPool(containerId);
+  });
+}
+
+// --- Mothball shelf ---
+
+// Models the user has shelved. Still visible, and one click from coming back,
+// but kept out of the working collection — and with no Log button, since
+// there's nothing to log against a deactivated model.
+function mothballShelfHtml(mothballed) {
+  const total = mothballed.reduce((sum, m) => sum + m.quantity, 0);
+  return `
+    <div class="folder-section folder-mothballed">
+      <div class="folder-header">
+        <button class="folder-toggle" id="mothballToggle">
+          <span class="folder-chevron">${_mothballCollapsed ? '▶' : '▼'}</span>
+          <span class="folder-icon">🧊</span>
+          <span class="folder-name">Mothballed</span>
+          <span class="folder-count">${mothballed.length}</span>
+        </button>
+      </div>
+      ${_mothballCollapsed ? '' : `
+        <div class="folder-models">
+          <p class="mothball-note">
+            ${total} model${total !== 1 ? 's' : ''} shelved — deactivated, so they don't count toward your pile,
+            Grey Brigade, rectitude or completion. Progress is kept: bring one back and it picks up where it left off.
+          </p>
+          <div class="model-grid">${mothballed.map(modelCard).join('')}</div>
+        </div>
+      `}
+    </div>
+  `;
+}
+
+function confirmMothball(modelId) {
+  const model = appData.models[modelId];
+  if (!model) return;
+  const msg = `Mothball "${model.name}"?\n\nIt stays in your collection but goes inert — you can't log progress against it, and it stops counting toward your pile, Grey Brigade, rectitude and completion stats. Its current progress is kept, and you can bring it back any time.`;
+  if (!window.confirm(msg)) return;
+  setModelMothballed(modelId, true);
+  toast(`🧊 "${model.name}" mothballed`, 'info');
+  renderModelPool();
+}
+
+function unmothballModel(modelId) {
+  const model = appData.models[modelId];
+  if (!model) return;
+  setModelMothballed(modelId, false);
+  toast(`♻️ "${model.name}" is back in service`, 'success');
+  renderModelPool();
 }
 
 function qtyLabel(model) {
@@ -298,21 +382,25 @@ function modelCard(model) {
 
   const thresh = modelThreshold(model);
   const badge = thresholdBadge(thresh);
+  const mothballed = isMothballed(model);
 
   return `
-    <div class="model-card" data-model-view="${model.id}">
+    <div class="model-card${mothballed ? ' model-card-mothballed' : ''}" data-model-view="${model.id}">
       ${model.image ? `<img class="model-card-thumb" src="${model.image}" alt="">` : ''}
       <div class="model-card-header">
         <div>
           <div class="model-card-name">${model.name}</div>
           <div class="model-card-qty">${qtyLabel(model)}</div>
         </div>
-        ${badge}
+        ${mothballed ? '<span class="mothball-badge">🧊 Mothballed</span>' : badge}
       </div>
       ${progressBar(pts.pct)}
       <div class="model-card-pts">${pts.pct}% complete <span class="pts-detail">${pts.done}/${pts.total} pts</span></div>
       <div class="model-card-actions">
-        <button class="btn btn-sm btn-primary" data-model-log="${model.id}">📝 Log</button>
+        ${mothballed
+          ? `<button class="btn btn-sm btn-primary" data-model-unmothball="${model.id}">♻️ Unmothball</button>`
+          : `<button class="btn btn-sm btn-primary" data-model-log="${model.id}">📝 Log</button>
+             <button class="btn btn-sm" data-model-mothball="${model.id}" title="Mothball — shelve this model so it stops counting toward anything">🧊</button>`}
         <button class="btn btn-sm" data-model-edit="${model.id}">✏️</button>
         <button class="btn btn-sm btn-danger" data-model-delete="${model.id}">🗑️</button>
       </div>
@@ -335,6 +423,8 @@ export function showModelDetail(modelId) {
     stageRow(s, model.progress[s.id], stageCap(s, model), skipped)
   ).join('');
 
+  const mothballed = isMothballed(model);
+
   const content = document.createElement('div');
   content.innerHTML = `
     ${model.image ? `<img class="detail-image" src="${model.image}" alt="${model.name}">` : ''}
@@ -343,20 +433,35 @@ export function showModelDetail(modelId) {
         <div class="detail-qty">${qtyLabel(model)}</div>
         ${model.notes ? `<div class="detail-notes">${model.notes}</div>` : ''}
       </div>
-      ${thresholdBadge(thresh)}
+      ${mothballed ? '<span class="mothball-badge">🧊 Mothballed</span>' : thresholdBadge(thresh)}
     </div>
+    ${mothballed ? `<div class="mothball-note">
+      Deactivated${model.mothballedDate ? ` on ${formatDate(model.mothballedDate)}` : ''} — it can't be worked on and doesn't count toward
+      your pile, Grey Brigade, rectitude or completion stats. The progress below is held exactly as it was.
+    </div>` : ''}
     ${progressBar(pts.pct)}
     <div class="detail-pts">${pts.done} / ${pts.total} pts (${pts.pct}%)</div>
     <div class="stages-list">${stagesHtml}</div>
     <div class="modal-actions">
-      <button class="btn btn-primary" id="detailLogBtn">📝 Log Progress</button>
+      ${mothballed
+        ? `<button class="btn btn-primary" id="detailUnmothballBtn">♻️ Unmothball</button>`
+        : `<button class="btn btn-primary" id="detailLogBtn">📝 Log Progress</button>`}
       <button class="btn" id="detailEditBtn">✏️ Edit</button>
+      ${mothballed ? '' : `<button class="btn" id="detailMothballBtn">🧊 Mothball</button>`}
     </div>
   `;
 
-  content.querySelector('#detailLogBtn').addEventListener('click', () => {
+  content.querySelector('#detailLogBtn')?.addEventListener('click', () => {
     closeModal();
     showLogProgress(modelId);
+  });
+  content.querySelector('#detailMothballBtn')?.addEventListener('click', () => {
+    closeModal();
+    confirmMothball(modelId);
+  });
+  content.querySelector('#detailUnmothballBtn')?.addEventListener('click', () => {
+    closeModal();
+    unmothballModel(modelId);
   });
   content.querySelector('#detailEditBtn').addEventListener('click', () => {
     closeModal();
@@ -767,6 +872,10 @@ function confirmDeleteModel(modelId) {
 export function showLogProgress(modelId) {
   const model = appData.models[modelId];
   if (!model) return;
+  if (isMothballed(model)) {
+    toast(`"${model.name}" is mothballed — unmothball it to log progress`, 'warning');
+    return;
+  }
 
   const stages = (model.stages || appData.config.stages).filter(s => !(model.skippedStages || []).includes(s.id));
   const hasCrew = (model.stages || appData.config.stages).some(s => s.group === 'crew');

--- a/js/roadmap.js
+++ b/js/roadmap.js
@@ -4,7 +4,7 @@
 import {
   appData, GAME_SYSTEMS, listStats, modelPoints, modelThreshold, splitModelPoints,
   getRoadmapLists, addListToRoadmap, removeListFromRoadmap, moveRoadmapList,
-  addCampaignSprint, getCampaignSprints
+  addCampaignSprint, getCampaignSprints, isMothballed
 } from './data.js';
 import { toast, progressBar, thresholdBadge, formatDate, daysUntil, today, addDays } from './ui.js';
 import { selectCollection, selectList } from './collections.js';
@@ -173,7 +173,7 @@ export function renderRoadmap(containerId = 'roadmapView') {
       const campaignSprints = getCampaignSprints(list);
       const unplanned = (list.modelIds || [])
         .map(id => appData.models[id])
-        .filter(m => m && modelThreshold(m) !== 'finished' && claimedQty(campaignSprints, m.id) < m.quantity);
+        .filter(m => m && !isMothballed(m) && modelThreshold(m) !== 'finished' && claimedQty(campaignSprints, m.id) < m.quantity);
 
       if (!unplanned.length) {
         toast('Everything in this campaign is already in a sprint', 'info');
@@ -275,8 +275,12 @@ function campaignCard(list, idx, total) {
   }
 
   const models = (list.modelIds || []).map(id => appData.models[id]).filter(Boolean);
-  const activeModels = models.filter(m => modelThreshold(m) !== 'finished');
-  const finishedModels = models.filter(m => modelThreshold(m) === 'finished');
+  // Mothballed models are neither outstanding work nor finished — they're out
+  // of the campaign's reckoning until they're brought back.
+  const mothballedModels = models.filter(isMothballed);
+  const liveModels = models.filter(m => !isMothballed(m));
+  const activeModels = liveModels.filter(m => modelThreshold(m) !== 'finished');
+  const finishedModels = liveModels.filter(m => modelThreshold(m) === 'finished');
   const showFinished = _showFinishedFor.has(list.id);
 
   const remainingPts = stats.totalPts - stats.donePts;
@@ -339,6 +343,7 @@ function campaignCard(list, idx, total) {
           </button>
           ${showFinished ? `<div class="roadmap-finished-list">${finishedModels.map(campaignModelRow).join('')}</div>` : ''}
         ` : ''}
+        ${mothballedModels.length ? `<p class="folder-empty">🧊 ${mothballedModels.length} mothballed and not counted here.</p>` : ''}
       </div>
     </div>
   `;

--- a/js/sprint.js
+++ b/js/sprint.js
@@ -3,7 +3,7 @@
 
 import {
   appData, saveData, uid, modelThreshold, modelPoints, getRoadmapLists,
-  splitModelPoints, splitModelThreshold, splitModelDoneCount
+  splitModelPoints, splitModelThreshold, splitModelDoneCount, isMothballed
 } from './data.js';
 import { showModal, closeModal, toast, thresholdBadge, progressBar, createDateInput, getDateValue, formatDate, today, addDays } from './ui.js';
 import { showLogProgress } from './models.js';
@@ -155,6 +155,9 @@ function sprintRemainingPoints(sprint) {
   return sprint.entries.reduce((sum, e) => {
     const model = appData.models[e.modelId];
     if (!model) return sum;
+    // Mothballed models can't be worked on, so they're not work this sprint
+    // has to absorb — leaving one in only holds its place in the order.
+    if (isMothballed(model)) return sum;
     const pts = entryPoints(model, e);
     return sum + Math.max(0, pts.total - pts.done);
   }, 0);
@@ -428,19 +431,23 @@ function sprintEntryCard(entry, idx, total, sprintId) {
       : `×${entry.chunkSize} of ${model.quantity}`)
     : `×${model.quantity}`;
 
+  const mothballed = isMothballed(model);
+
   return `
-    <div class="queue-entry ${isFirst ? 'queue-entry-next' : ''}" data-entry-id="${entry.id}" data-sprint-id="${sprintId}">
-      ${isFirst ? '<div class="queue-up-next-label">⭐ Up Next</div>' : ''}
+    <div class="queue-entry ${isFirst ? 'queue-entry-next' : ''}${mothballed ? ' queue-entry-mothballed' : ''}" data-entry-id="${entry.id}" data-sprint-id="${sprintId}">
+      ${isFirst && !mothballed ? '<div class="queue-up-next-label">⭐ Up Next</div>' : ''}
       <div class="queue-entry-main">
         <div class="queue-entry-info">
           <div class="queue-entry-name">${model.name}${isChunk ? ' <span class="split-badge">partial</span>' : ''}</div>
           <div class="queue-entry-qty">${qtyLabel}</div>
-          ${thresholdBadge(thresh)}
+          ${mothballed ? '<span class="mothball-badge">🧊 Mothballed</span>' : thresholdBadge(thresh)}
         </div>
         ${progressBar(pts.pct)}
         ${entry.note ? `<div class="queue-entry-note">📌 ${entry.note}</div>` : ''}
         <div class="queue-entry-actions">
-          <button class="btn btn-sm btn-primary" data-log-model="${entry.modelId}">📝 Log</button>
+          ${mothballed
+            ? `<span class="queue-entry-inert">Mothballed — remove it, or unmothball it in the Pool</span>`
+            : `<button class="btn btn-sm btn-primary" data-log-model="${entry.modelId}">📝 Log</button>`}
           <button class="btn btn-sm" data-edit-note="${entry.id}">📌 Note</button>
           ${model.quantity > 1 ? `<button class="btn btn-sm" data-edit-qty="${entry.id}" title="Change how many of this regiment are in this sprint">✂️ Qty</button>` : ''}
           <div class="queue-move-btns">
@@ -616,6 +623,7 @@ function showAddToSprint(sprintId) {
 
   const renderPicker = (filter = '', folderId = '') => {
     const available = allModels.filter(m => {
+      if (isMothballed(m)) return false;
       if (modelThreshold(m) === 'finished') return false;
       if (wholeEntryModelIds.has(m.id)) return false;
       const matchName = m.name.toLowerCase().includes(filter.toLowerCase());
@@ -623,7 +631,7 @@ function showAddToSprint(sprintId) {
       return matchName && matchFolder;
     });
 
-    if (!available.length) return '<p style="color:var(--text-muted);font-size:0.85em;padding:0.5em 0">No available models. Finished models and models already in this sprint are excluded.</p>';
+    if (!available.length) return '<p style="color:var(--text-muted);font-size:0.85em;padding:0.5em 0">No available models. Finished models, mothballed models and models already in this sprint are excluded.</p>';
 
     return available.map(m => `
       <label class="pool-pick-item">

--- a/js/tips.js
+++ b/js/tips.js
@@ -3,7 +3,7 @@
 // unused (or a situation where it would help) so people who already lean on
 // a feature stop getting nagged about it — the tip simply stops matching.
 
-import { appData, saveData, getAllModels, getAllModelTypes, modelThreshold, GAME_SYSTEMS, getRoadmapLists, getCampaignSprints, getModelDateAdded, resolveGameSystemId, unstartedCount, greyBrigadeCount } from './data.js';
+import { appData, saveData, getActiveModels, getMothballedModels, getAllModelTypes, modelThreshold, GAME_SYSTEMS, getRoadmapLists, getCampaignSprints, getModelDateAdded, resolveGameSystemId, unstartedCount, greyBrigadeCount } from './data.js';
 import { BADGES, oldestPileModel } from './badges.js';
 import { getBurndownWindow } from './charts.js';
 import { isConfigured, wasConnected } from './gdrive.js';
@@ -53,6 +53,12 @@ const TIP_DEFINITIONS = [
     icon: '🧩',
     text: "Got a unit that doesn't fit the built-in types? Create a Custom Model Type in Settings for precise stage tracking.",
     condition: ctx => (appData.config.modelTypes || []).length === 0 && ctx.modelCount >= 12
+  },
+  {
+    id: 'mothball',
+    icon: '🧊',
+    text: "Got something you'll realistically never get round to? Mothball it (🧊 on its card in the Model Pool). It stays in your collection with its progress intact, but goes inert — no logging, and it stops counting toward your pile, Grey Brigade and rectitude. Unmothball it whenever you change your mind.",
+    condition: ctx => ctx.mothballedCount === 0 && ctx.oldestPileAgeDays >= 365
   },
   {
     id: 'quartermaster',
@@ -165,7 +171,9 @@ const TIP_DEFINITIONS = [
 ];
 
 function buildContext() {
-  const models = getAllModels();
+  // Mothballed models are shelved — they shouldn't trigger nudges about work
+  // the user has explicitly decided not to do.
+  const models = getActiveModels();
   const folders = appData.folders || {};
   const sprints = Object.values(appData.sprints || {});
   const lists = Object.values(appData.lists || {});
@@ -239,6 +247,7 @@ function buildContext() {
 
   return {
     modelCount: models.length,
+    mothballedCount: getMothballedModels().length,
     folderCount: Object.keys(folders).length,
     sprintEntryCount,
     sprintCount: sprints.length,


### PR DESCRIPTION
A mothballed model stays in your collection but goes inert. You can't log
progress against it, and it drops out of every hobby stat — the pile, the
Grey Brigade, rectitude, completion percentages, army list and campaign
totals. Nothing is destroyed while it sleeps, so unmothballing brings it
back with its progress exactly as it was.

Data layer:
- `mothballed` / `mothballedDate` on the model, plus isMothballed(),
  getActiveModels(), getMothballedModels() and setModelMothballed().
- unstartedCount() and greyBrigadeCount() return 0 for a mothballed model,
  which is what keeps it out of pileCount/pileWorth and so out of rectitude
  everywhere those are consumed.
- logProgress() refuses outright, so no caller can put work against
  something the user has explicitly shelved.
- globalStats() and listStats() skip them: shelving something you'll never
  paint shouldn't go on dragging your completion down forever, or leave an
  army list permanently short of 100%.

UI:
- Model Pool gets a collapsible "Mothballed" shelf at the bottom, with a
  🧊 button on every working card and an ♻️ Unmothball on every shelved
  one. Select mode gains a mass-mothball action alongside the mass move.
- The detail modal offers both directions and explains what shelving does.
- Army lists, sprints and roadmap campaigns badge a mothballed member,
  drop its Log button, and leave it out of their totals and capacity;
  the sprint and army-list pickers no longer offer them.
- Dashboard footnotes the pile with how many are shelved, so a model you
  mothballed doesn't just silently vanish from the count.
- Badges use active models, so shelving everything can't award Zero Shame
  and a shelved model can't block Sprue Slayer.
- New tip pointing at the feature once something's been on the pile a year.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01QAGyxUSGBZddsm9EDsmTYU